### PR TITLE
rename AddCleanup to Defer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+go_import_path: github.com/frankban/quicktest
 
 go:
   - "1.7"

--- a/patch.go
+++ b/patch.go
@@ -9,13 +9,13 @@ import (
 )
 
 // Patch sets a variable to a temporary value for the duration of the
-// test (until c.Cleanup is called).
+// test (until c.Done is called).
 //
 // It sets the value pointed to by the given destination to the given
 // value, which must be assignable to the element type of the
 // destination.
 //
-// When c.Cleanup is called, the destination is set to its original
+// When c.Done is called, the destination is set to its original
 // value.
 func (c *C) Patch(dest, value interface{}) {
 	destv := reflect.ValueOf(dest).Elem()
@@ -28,20 +28,20 @@ func (c *C) Patch(dest, value interface{}) {
 		valuev = reflect.Zero(destv.Type())
 	}
 	destv.Set(valuev)
-	c.AddCleanup(func() {
+	c.Defer(func() {
 		destv.Set(oldv)
 	})
 }
 
 // Setenv sets an environment variable to a temporary value for the
-// duration of the test (until c.Cleanup is called).
+// duration of the test (until c.Done is called).
 //
-// When c.Cleanup is called, the environment variable will be returned
+// When c.Done is called, the environment variable will be returned
 // to its original value.
 func (c *C) Setenv(name, val string) {
 	oldVal := os.Getenv(name)
 	os.Setenv(name, val)
-	c.AddCleanup(func() {
+	c.Defer(func() {
 		os.Setenv(name, oldVal)
 	})
 }
@@ -49,11 +49,11 @@ func (c *C) Setenv(name, val string) {
 // Mkdir makes a temporary directory and returns its name.
 //
 // The directory and its contents will be removed when
-// c.Cleanup is called.
+// c.Done is called.
 func (c *C) Mkdir() string {
 	name, err := ioutil.TempDir("", "quicktest-")
 	c.Assert(err, Equals, nil)
-	c.AddCleanup(func() {
+	c.Defer(func() {
 		err := os.RemoveAll(name)
 		c.Check(err, Equals, nil)
 	})

--- a/patch_test.go
+++ b/patch_test.go
@@ -16,7 +16,7 @@ func TestPatchSetInt(t *testing.T) {
 	i := 99
 	c.Patch(&i, 88)
 	c.Assert(i, qt.Equals, 88)
-	c.Cleanup()
+	c.Done()
 	c.Assert(i, qt.Equals, 99)
 }
 
@@ -27,7 +27,7 @@ func TestPatchSetError(t *testing.T) {
 	err := oldErr
 	c.Patch(&err, newErr)
 	c.Assert(err, qt.Equals, newErr)
-	c.Cleanup()
+	c.Done()
 	c.Assert(err, qt.Equals, oldErr)
 }
 
@@ -37,7 +37,7 @@ func TestPatchSetErrorToNil(t *testing.T) {
 	err := oldErr
 	c.Patch(&err, nil)
 	c.Assert(err, qt.Equals, nil)
-	c.Cleanup()
+	c.Done()
 	c.Assert(err, qt.Equals, oldErr)
 }
 
@@ -47,7 +47,7 @@ func TestPatchSetMapToNil(t *testing.T) {
 	m := oldMap
 	c.Patch(&m, nil)
 	c.Assert(m, qt.IsNil)
-	c.Cleanup()
+	c.Done()
 	c.Assert(m, qt.DeepEquals, oldMap)
 }
 
@@ -64,7 +64,7 @@ func TestSetenv(t *testing.T) {
 	os.Setenv(envName, "initial")
 	c.Setenv(envName, "new value")
 	c.Check(os.Getenv(envName), qt.Equals, "new value")
-	c.Cleanup()
+	c.Done()
 	c.Check(os.Getenv(envName), qt.Equals, "initial")
 }
 
@@ -78,7 +78,7 @@ func TestMkdir(t *testing.T) {
 	f, err := os.Create(filepath.Join(dir, "hello"))
 	c.Assert(err, qt.Equals, nil)
 	f.Close()
-	c.Cleanup()
+	c.Done()
 	_, err = os.Stat(dir)
 	c.Assert(err, qt.Not(qt.IsNil))
 }

--- a/qtsuite/suite.go
+++ b/qtsuite/suite.go
@@ -16,7 +16,7 @@ an HTTP server before running each test, and tears it down afterwards:
 			fmt.Fprintf(w, "%s %s", req.Method, req.URL.Path)
 		}
 		srv := httptest.NewServer(http.HandlerFunc(hnd))
-		c.AddCleanup(srv.Close)
+		c.Defer(srv.Close)
 		s.url = srv.URL
 	}
 


### PR DESCRIPTION
This naming more succinct, more Go-idiomatic, and more suggestive of the
semantics that are implemented (a LIFO stack of functions to run later).

We also rename Cleanup to Done (thinking of sync.WaitGroup.Done).

The old names are left in place as synonyms for now.
