### PR TITLE
fix ErrorMatches

### DIFF
--- a/checker.go
+++ b/checker.go
@@ -181,13 +181,13 @@ type errorMatchesChecker struct {
 // Check implements Checker.Check by checking that got is an error whose
 // Error() matches args[0].
 func (c *errorMatchesChecker) Check(got interface{}, args []interface{}, note func(key string, value interface{})) error {
+	if got == nil {
+		return errors.New("got nil error but want non-nil")
+	}
 	err, ok := got.(error)
 	if !ok {
 		note("got", got)
 		return BadCheckf("first argument is not an error")
-	}
-	if err == nil {
-		return errors.New("no error found")
 	}
 	return match(err.Error(), args[0], "error does not match regexp", note)
 }

--- a/checker_test.go
+++ b/checker_test.go
@@ -978,18 +978,14 @@ got:
 	about:   "ErrorMatches: nil error",
 	checker: qt.ErrorMatches,
 	got:     nil,
-	args:    []interface{}{".*"},
+	args:    []interface{}{"some pattern"},
 	expectedCheckFailure: `
 error:
-  bad check: first argument is not an error
-got:
+  got nil error but want non-nil
+got error:
   nil
-`,
-	expectedNegateFailure: `
-error:
-  bad check: first argument is not an error
-got:
-  nil
+regexp:
+  "some pattern"
 `,
 }, {
 	about:   "ErrorMatches: not enough arguments",


### PR DESCRIPTION
If we do `c.Assert(err, qt.ErrorMatches, pattern)` and err is nil, we want the resulting failure to print the expected error message pattern, not that it's a bad check.
