### PR TITLE
avoid Fprintf with unknown format messages.

### DIFF
--- a/quicktest_test.go
+++ b/quicktest_test.go
@@ -38,6 +38,19 @@ want:
   "47"
 `,
 }, {
+	about:   "failure with % signs",
+	checker: qt.Equals,
+	got:     "42%x",
+	args:    []interface{}{"47%y"},
+	expectedFailure: `
+error:
+  values are not equal
+got:
+  "42%x"
+want:
+  "47%y"
+`,
+}, {
 	about:   "failure with comment",
 	checker: qt.Equals,
 	got:     true,

--- a/report.go
+++ b/report.go
@@ -45,11 +45,11 @@ func writeError(w io.Writer, argNames []string, got interface{}, args []interfac
 		}
 		fmt.Fprintln(w, key+":")
 		if k := values[v]; k != "" {
-			fmt.Fprintf(w, prefixf(prefix, "<same as %q>", k))
+			fmt.Fprint(w, prefixf(prefix, "<same as %q>", k))
 			return
 		}
 		values[v] = key
-		fmt.Fprintf(w, prefixf(prefix, "%s", v))
+		fmt.Fprint(w, prefixf(prefix, "%s", v))
 	}
 
 	// Write the checker error.
@@ -85,14 +85,14 @@ func writeInvocation(w io.Writer) {
 	// TODO: we can do better than 4.
 	_, file, line, ok := runtime.Caller(4)
 	if !ok {
-		fmt.Fprintf(w, prefixf(prefix, "<invocation not available>"))
+		fmt.Fprint(w, prefixf(prefix, "<invocation not available>"))
 		return
 	}
-	fmt.Fprintf(w, prefixf(prefix, "%s:%d:", filepath.Base(file), line))
+	fmt.Fprint(w, prefixf(prefix, "%s:%d:", filepath.Base(file), line))
 	prefix := prefix + prefix
 	f, err := os.Open(file)
 	if err != nil {
-		fmt.Fprintf(w, prefixf(prefix, "<cannot open source file: %s>", err))
+		fmt.Fprint(w, prefixf(prefix, "<cannot open source file: %s>", err))
 		return
 	}
 	defer f.Close()
@@ -117,11 +117,11 @@ func writeInvocation(w io.Writer) {
 	}
 	tw.Flush()
 	if err = sc.Err(); err != nil {
-		fmt.Fprintf(w, prefixf(prefix, "<cannot scan source file: %s>", err))
+		fmt.Fprint(w, prefixf(prefix, "<cannot scan source file: %s>", err))
 		return
 	}
 	if !found {
-		fmt.Fprintf(w, prefixf(prefix, "<cannot find source lines>"))
+		fmt.Fprint(w, prefixf(prefix, "<cannot find source lines>"))
 	}
 }
 


### PR DESCRIPTION
When quicktest failed with a % character in the message,
we get an inappropriately fmt-formatted string, so fix
that by using Fprint instead of Fprintf.