### PR TITLE
Produce a stack trace instead of a code context

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -2,4 +2,7 @@
 
 package quicktest
 
-var Prefixf = prefixf
+var (
+	InternalCmpEquals = cmpEquals
+	Prefixf           = prefixf
+)

--- a/quicktest_test.go
+++ b/quicktest_test.go
@@ -513,7 +513,7 @@ func TestCRunDefer(t *testing.T) {
 
 func checkResult(t *testing.T, ok bool, got, want string) {
 	if want != "" {
-		assertPrefix(t, got, want)
+		assertPrefix(t, got, want+"stack:\n")
 		assertBool(t, ok, false)
 		return
 	}

--- a/report_test.go
+++ b/report_test.go
@@ -3,48 +3,111 @@
 package quicktest_test
 
 import (
+	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
 )
 
-// This test lives in its own file as it relies on its own source code lines.
+// The tests in this file rely on their own source code lines.
 
-func TestCodeOutput(t *testing.T) {
+func TestReportOutput(t *testing.T) {
 	tt := &testingT{}
 	c := qt.New(tt)
-	// Context line #1.
-	// Context line #2.
-	// Context line #3.
 	c.Assert(42, qt.Equals, 47)
-	// Context line #4.
-	// Context line #5.
-	// Context line #6.
-	codeOutput := strings.Replace(tt.fatalString(), "\t", "        ", -1)
-	if codeOutput != expectedCodeOutput {
-		t.Fatalf(`failure:
------------------------------- got ------------------------------
-%s------------------------------ want -----------------------------
-%s-----------------------------------------------------------------`,
-			codeOutput, expectedCodeOutput)
-	}
-}
-
-var expectedCodeOutput = `
+	want := `
 error:
   values are not equal
 got:
   int(42)
 want:
   int(47)
-sources:
-  report_test.go:20:
-    17     // Context line #1.
-    18     // Context line #2.
-    19     // Context line #3.
-    20!    c.Assert(42, qt.Equals, 47)
-    21     // Context line #4.
-    22     // Context line #5.
-    23     // Context line #6.
+stack:
+  $file:19
+    c.Assert(42, qt.Equals, 47)
 `
+	assertReport(t, tt, want)
+}
+
+func f1(c *qt.C) {
+	f2(c)
+}
+
+func f2(c *qt.C) {
+	c.Assert(42, qt.IsNil) // Real assertion here!
+}
+
+func TestIndirectReportOutput(t *testing.T) {
+	tt := &testingT{}
+	c := qt.New(tt)
+	f1(c)
+	want := `
+error:
+  42 is not nil
+got:
+  int(42)
+stack:
+  $file:39
+    c.Assert(42, qt.IsNil)
+  $file:35
+    f2(c)
+  $file:45
+    f1(c)
+`
+	assertReport(t, tt, want)
+}
+
+func TestMultilineReportOutput(t *testing.T) {
+	tt := &testingT{}
+	c := qt.New(tt)
+	c.Assert(
+		"this string", // Comment 1.
+		qt.Equals,
+		"another string",
+		qt.Commentf("a comment"), // Comment 2.
+	) // Comment 3.
+	want := `
+error:
+  values are not equal
+comment:
+  a comment
+got:
+  "this string"
+want:
+  "another string"
+stack:
+  $file:$line
+    c.Assert(
+        "this string", // Comment 1.
+        qt.Equals,
+        "another string",
+        qt.Commentf("a comment"), // Comment 2.
+    )
+`
+	assertReport(t, tt, want)
+}
+
+func assertReport(t *testing.T, tt *testingT, want string) {
+	got := strings.Replace(tt.fatalString(), "\t", "        ", -1)
+	// Adjust for file names in different systems.
+	_, file, _, ok := runtime.Caller(0)
+	assertBool(t, ok, true)
+	want = strings.Replace(want, "$file", file, -1)
+	// Adjust for line number based on Go < v1.9 reporting the line where the
+	// statement ends.
+	line := 65
+	vers := runtime.Version()
+	if vers == "go1.7" || vers == "go1.8" {
+		line = 70
+	}
+	want = strings.Replace(want, "$line", strconv.Itoa(line), 1)
+	if got != want {
+		t.Fatalf(`failure:
+------------------------------ got ------------------------------
+%s------------------------------ want -----------------------------
+%s-----------------------------------------------------------------`,
+			got, want)
+	}
+}


### PR DESCRIPTION
Now multiline statements are printed as part of the stack message, together with full path of test files.
Also only show values in Cmp/DeepEquals error outputs when "go test -v" is used, in order to reduce noise.
