### PR TITLE
make methods concurrent-safe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,10 @@ go:
   - "1.8"
   - "1.9"
   - "1.10"
-  - "1.11"
+  - "1.11.x"
+  - "1.12.x"
   - 1.x
   - master
 
 script:
-  - go get -v github.com/rogpeppe/godeps
-  - $GOPATH/bin/godeps -u dependencies.tsv
-  - GO111MODULE=on go test ./...
-  - GO111MODULE=on go test -v ./...
+  - GO111MODULE=on go test -race ./...

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,3 +1,0 @@
-github.com/google/go-cmp	git	6f77996f0c42f7b84e5a2b252227263f93432e9b	2019-03-12T03:24:27Z
-github.com/kr/pretty	git	73f6ac0b30a98e433b289500d779f50c1a6f0712	2018-05-06T08:33:45Z
-github.com/kr/text	git	e2ffdb16a802fe2bb95e2e35ff34f0e53aeef34f	2018-05-06T08:24:08Z

--- a/race_test.go
+++ b/race_test.go
@@ -1,0 +1,84 @@
+package quicktest_test
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestConcurrentMethods(t *testing.T) {
+	// This test is designed to be run with the race
+	// detector enabled. It checks that C methods
+	// are safe to call concurrently.
+
+	// N holds the number of iterations to run any given
+	// operation concurrently with the others.
+	const N = 100
+
+	var x, y int32
+	c := qt.New(dummyT{})
+	var wg sync.WaitGroup
+	// start calls f in two goroutines, each
+	// running it N times.
+	// All the goroutines get started before we actually
+	// start them running, so that the race detector
+	// has a better chance of catching issues.
+	gogogo := make(chan struct{})
+	start := func(f func()) {
+		repeat := func() {
+			defer wg.Done()
+			<-gogogo
+			for i := 0; i < N; i++ {
+				f()
+			}
+		}
+		wg.Add(2)
+		go repeat()
+		go repeat()
+	}
+	start(func() {
+		c.Defer(func() {
+			atomic.AddInt32(&x, 1)
+		})
+		c.Defer(func() {
+			atomic.AddInt32(&y, 1)
+		})
+	})
+	start(func() {
+		c.Done()
+	})
+	start(func() {
+		c.SetFormat(func(v interface{}) string {
+			return "x"
+		})
+	})
+	start(func() {
+		// Do an assert to exercise the formatter.
+		c.Check(true, qt.Equals, false)
+	})
+	start(func() {
+		c.Run("", func(c *qt.C) {})
+	})
+	close(gogogo)
+	wg.Wait()
+	c.Done()
+
+	// Check that all the defer functions ran OK.
+	if x != N*2 || y != N*2 {
+		t.Fatalf("unexpected x, y counts; got %d, %d; want %d, %d", x, y, N*2, N*2)
+	}
+}
+
+// dummyT implements the testing.TB methods
+// required for TestConcurentMethods.
+type dummyT struct {
+	testing.TB
+}
+
+func (dummyT) Error(...interface{}) {}
+
+func (dummyT) Run(name string, f func(t *testing.T)) bool {
+	return false
+}


### PR DESCRIPTION
This makes things a little more bombproof - it's
also potentially useful to be able to use `Defer`
in a goroutine.

Also make the zero value of a `*quicktest.C` good to
use, so it appears to be just a simple wrapper around
`testing.TB`.