### PR TITLE
add JSONEquals and CodecEquals

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -22,6 +22,10 @@ func WithVerbosity(c Checker, v bool) Checker {
 			return v
 		}
 		return &c
+	case *codecEqualChecker:
+		c := *checker
+		c.deepEquals = WithVerbosity(c.deepEquals, v)
+		return &c
 	}
 	return c
 }

--- a/go.mod
+++ b/go.mod
@@ -4,3 +4,5 @@ require (
 	github.com/google/go-cmp v0.3.0
 	github.com/kr/pretty v0.1.0
 )
+
+go 1.12


### PR DESCRIPTION
These checkers make it easy to check for marshaled equivalence
of encoded strings.