### PR TITLE
Remove deprecated AddCleanup/Cleanup

### DIFF
--- a/quicktest.go
+++ b/quicktest.go
@@ -95,20 +95,6 @@ func (c *C) Done() {
 	}
 }
 
-// AddCleanup is the old name for Defer.
-//
-// Deprecated: this will be removed in a subsequent version.
-func (c *C) AddCleanup(f func()) {
-	c.Defer(f)
-}
-
-// Cleanup is the old name for Done.
-//
-// Deprecated: this will be removed in a subsequent version.
-func (c *C) Cleanup() {
-	c.Done()
-}
-
 // SetFormat sets the function used to print values in test failures.
 // By default Format is used.
 // Any subsequent subtests invoked with c.Run will also use this function by

--- a/quicktest_test.go
+++ b/quicktest_test.go
@@ -13,6 +13,8 @@ import (
 	qt "github.com/frankban/quicktest"
 )
 
+var _ testing.TB = (*qt.C)(nil)
+
 var cTests = []struct {
 	about           string
 	checker         qt.Checker


### PR DESCRIPTION
Go 1.14 has changed the signature of `Cleanup` in `testing.TB`.
This commit gets `quicktest.C` in line with that interface.

Fixes #54