### PR TITLE
integrate Defer with Cleanup

### DIFF
--- a/cleanup_test.go
+++ b/cleanup_test.go
@@ -1,0 +1,68 @@
+// +build go1.14
+
+package quicktest_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// This file defines tests that are only valid since the Cleanup
+// method was added in Go 1.14.
+
+func TestCCleanup(t *testing.T) {
+	c := qt.New(t)
+	cleanups := 0
+	c.Run("defer", func(c *qt.C) {
+		c.Cleanup(func() {
+			cleanups++
+		})
+	})
+	c.Assert(cleanups, qt.Equals, 1)
+}
+
+func TestCDeferWithoutDone(t *testing.T) {
+	c := qt.New(t)
+	tc := &testingTWithCleanup{
+		TB:      t,
+		cleanup: func() {},
+	}
+	c1 := qt.New(tc)
+	c1.Defer(func() {})
+	c1.Defer(func() {})
+	c.Assert(tc.cleanup, qt.PanicMatches, `Done not called after Defer`)
+}
+
+func TestCDeferVsCleanupOrder(t *testing.T) {
+	c := qt.New(t)
+	var defers []int
+	testDefer(c, func(c *qt.C) {
+		c.Defer(func() {
+			defers = append(defers, 0)
+		})
+		c.Cleanup(func() {
+			defers = append(defers, 1)
+		})
+		c.Defer(func() {
+			defers = append(defers, 2)
+		})
+		c.Cleanup(func() {
+			defers = append(defers, 3)
+		})
+	})
+	c.Assert(defers, qt.DeepEquals, []int{3, 2, 1, 0})
+}
+
+type testingTWithCleanup struct {
+	testing.TB
+	cleanup func()
+}
+
+func (t *testingTWithCleanup) Cleanup(f func()) {
+	oldCleanup := t.cleanup
+	t.cleanup = func() {
+		defer oldCleanup()
+		f()
+	}
+}

--- a/deferpanic_test.go
+++ b/deferpanic_test.go
@@ -1,0 +1,41 @@
+// +build !go1.14
+
+package quicktest_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestCDeferCalledEvenAfterDeferPanic(t *testing.T) {
+	// This test doesn't test anything useful under go 1.14 and
+	// later when Cleanup is built in.
+	c := qt.New(t)
+	deferred1 := 0
+	deferred2 := 0
+	c.Defer(func() {
+		deferred1++
+	})
+	c.Defer(func() {
+		panic("scream and shout")
+	})
+	c.Defer(func() {
+		deferred2++
+	})
+	c.Defer(func() {
+		panic("run in circles")
+	})
+	func() {
+		defer func() {
+			c.Check(recover(), qt.Equals, "scream and shout")
+		}()
+		c.Done()
+	}()
+	c.Assert(deferred1, qt.Equals, 1)
+	c.Assert(deferred2, qt.Equals, 1)
+	// Check that calling Done again doesn't panic.
+	c.Done()
+	c.Assert(deferred1, qt.Equals, 1)
+	c.Assert(deferred2, qt.Equals, 1)
+}

--- a/patch_test.go
+++ b/patch_test.go
@@ -14,9 +14,10 @@ import (
 func TestPatchSetInt(t *testing.T) {
 	c := qt.New(t)
 	i := 99
-	c.Patch(&i, 88)
-	c.Assert(i, qt.Equals, 88)
-	c.Done()
+	testDefer(c, func(c *qt.C) {
+		c.Patch(&i, 88)
+		c.Assert(i, qt.Equals, 88)
+	})
 	c.Assert(i, qt.Equals, 99)
 }
 
@@ -25,9 +26,10 @@ func TestPatchSetError(t *testing.T) {
 	oldErr := errors.New("foo")
 	newErr := errors.New("bar")
 	err := oldErr
-	c.Patch(&err, newErr)
-	c.Assert(err, qt.Equals, newErr)
-	c.Done()
+	testDefer(c, func(c *qt.C) {
+		c.Patch(&err, newErr)
+		c.Assert(err, qt.Equals, newErr)
+	})
 	c.Assert(err, qt.Equals, oldErr)
 }
 
@@ -35,9 +37,10 @@ func TestPatchSetErrorToNil(t *testing.T) {
 	c := qt.New(t)
 	oldErr := errors.New("foo")
 	err := oldErr
-	c.Patch(&err, nil)
-	c.Assert(err, qt.Equals, nil)
-	c.Done()
+	testDefer(c, func(c *qt.C) {
+		c.Patch(&err, nil)
+		c.Assert(err, qt.Equals, nil)
+	})
 	c.Assert(err, qt.Equals, oldErr)
 }
 
@@ -45,9 +48,10 @@ func TestPatchSetMapToNil(t *testing.T) {
 	c := qt.New(t)
 	oldMap := map[string]int{"foo": 1234}
 	m := oldMap
-	c.Patch(&m, nil)
-	c.Assert(m, qt.IsNil)
-	c.Done()
+	testDefer(c, func(c *qt.C) {
+		c.Patch(&m, nil)
+		c.Assert(m, qt.IsNil)
+	})
 	c.Assert(m, qt.DeepEquals, oldMap)
 }
 
@@ -62,23 +66,26 @@ func TestSetenv(t *testing.T) {
 	c := qt.New(t)
 	const envName = "SOME_VAR"
 	os.Setenv(envName, "initial")
-	c.Setenv(envName, "new value")
-	c.Check(os.Getenv(envName), qt.Equals, "new value")
-	c.Done()
+	testDefer(c, func(c *qt.C) {
+		c.Setenv(envName, "new value")
+		c.Check(os.Getenv(envName), qt.Equals, "new value")
+	})
 	c.Check(os.Getenv(envName), qt.Equals, "initial")
 }
 
 func TestMkdir(t *testing.T) {
 	c := qt.New(t)
-	dir := c.Mkdir()
-	c.Assert(c, qt.Not(qt.Equals), "")
-	info, err := os.Stat(dir)
-	c.Assert(err, qt.Equals, nil)
-	c.Assert(info.IsDir(), qt.Equals, true)
-	f, err := os.Create(filepath.Join(dir, "hello"))
-	c.Assert(err, qt.Equals, nil)
-	f.Close()
-	c.Done()
-	_, err = os.Stat(dir)
+	var dir string
+	testDefer(c, func(c *qt.C) {
+		dir = c.Mkdir()
+		c.Assert(dir, qt.Not(qt.Equals), "")
+		info, err := os.Stat(dir)
+		c.Assert(err, qt.Equals, nil)
+		c.Assert(info.IsDir(), qt.Equals, true)
+		f, err := os.Create(filepath.Join(dir, "hello"))
+		c.Assert(err, qt.Equals, nil)
+		f.Close()
+	})
+	_, err := os.Stat(dir)
 	c.Assert(err, qt.Not(qt.IsNil))
 }

--- a/race_test.go
+++ b/race_test.go
@@ -20,67 +20,71 @@ func TestConcurrentMethods(t *testing.T) {
 	const N = 100
 
 	var x, y int32
-	c := qt.New(dummyT{})
-	var wg sync.WaitGroup
-	// start calls f in two goroutines, each
-	// running it N times.
-	// All the goroutines get started before we actually
-	// start them running, so that the race detector
-	// has a better chance of catching issues.
-	gogogo := make(chan struct{})
-	start := func(f func()) {
-		repeat := func() {
-			defer wg.Done()
-			<-gogogo
-			for i := 0; i < N; i++ {
-				f()
+	c := qt.New(dummyT{t})
+	testDefer(c, func(c *qt.C) {
+		var wg sync.WaitGroup
+		// start calls f in two goroutines, each
+		// running it N times.
+		// All the goroutines get started before we actually
+		// start them running, so that the race detector
+		// has a better chance of catching issues.
+		gogogo := make(chan struct{})
+		start := func(f func()) {
+			repeat := func() {
+				defer wg.Done()
+				<-gogogo
+				for i := 0; i < N; i++ {
+					f()
+				}
 			}
+			wg.Add(2)
+			go repeat()
+			go repeat()
 		}
-		wg.Add(2)
-		go repeat()
-		go repeat()
-	}
-	start(func() {
-		c.Defer(func() {
-			atomic.AddInt32(&x, 1)
+		start(func() {
+			c.Defer(func() {
+				atomic.AddInt32(&x, 1)
+			})
+			c.Defer(func() {
+				atomic.AddInt32(&y, 1)
+			})
 		})
-		c.Defer(func() {
-			atomic.AddInt32(&y, 1)
+		start(func() {
+			c.Done()
 		})
-	})
-	start(func() {
-		c.Done()
-	})
-	start(func() {
-		c.SetFormat(func(v interface{}) string {
-			return "x"
+		start(func() {
+			c.SetFormat(func(v interface{}) string {
+				return "x"
+			})
 		})
+		start(func() {
+			// Do an assert to exercise the formatter.
+			c.Check(true, qt.Equals, false)
+		})
+		start(func() {
+			c.Run("", func(c *qt.C) {})
+		})
+		close(gogogo)
+		wg.Wait()
 	})
-	start(func() {
-		// Do an assert to exercise the formatter.
-		c.Check(true, qt.Equals, false)
-	})
-	start(func() {
-		c.Run("", func(c *qt.C) {})
-	})
-	close(gogogo)
-	wg.Wait()
-	c.Done()
-
 	// Check that all the defer functions ran OK.
 	if x != N*2 || y != N*2 {
 		t.Fatalf("unexpected x, y counts; got %d, %d; want %d, %d", x, y, N*2, N*2)
 	}
 }
 
-// dummyT implements the testing.TB methods
-// required for TestConcurentMethods.
+// dummyT wraps a *testing.T value suitable
+// for TestConcurrentMethods so that calling Error
+// won't fail the test and that it implements
+// Run correctly.
 type dummyT struct {
-	testing.TB
+	*testing.T
 }
 
 func (dummyT) Error(...interface{}) {}
 
-func (dummyT) Run(name string, f func(t *testing.T)) bool {
-	return false
+func (t dummyT) Run(name string, f func(t dummyT)) bool {
+	return t.T.Run(name, func(t *testing.T) {
+		f(dummyT{t})
+	})
 }


### PR DESCRIPTION
This means that Defer and Cleanup methods still execute in the correct order with respect to one another. We ensure that if you use Defer, you must use Done too.