### PR TITLE
implement Unsetenv

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -39,10 +39,29 @@ func (c *C) Patch(dest, value interface{}) {
 // When c.Done is called, the environment variable will be returned
 // to its original value.
 func (c *C) Setenv(name, val string) {
-	oldVal := os.Getenv(name)
-	os.Setenv(name, val)
+	c.setenv(name, val, true)
+}
+
+// Unsetenv unsets an environment variable for the duration of a test.
+func (c *C) Unsetenv(name string) {
+	c.setenv(name, "", false)
+}
+
+// setenv sets or unsets an environment variable to a temporary value for the
+// duration of the test
+func (c *C) setenv(name, val string, valOK bool) {
+	oldVal, oldOK := os.LookupEnv(name)
+	if valOK {
+		os.Setenv(name, val)
+	} else {
+		os.Unsetenv(name)
+	}
 	c.Defer(func() {
-		os.Setenv(name, oldVal)
+		if oldOK {
+			os.Setenv(name, oldVal)
+		} else {
+			os.Unsetenv(name)
+		}
 	})
 }
 

--- a/patch_test.go
+++ b/patch_test.go
@@ -73,6 +73,43 @@ func TestSetenv(t *testing.T) {
 	c.Check(os.Getenv(envName), qt.Equals, "initial")
 }
 
+func TestSetenvWithUnsetVariable(t *testing.T) {
+	c := qt.New(t)
+	const envName = "SOME_VAR"
+	os.Unsetenv(envName)
+	testDefer(c, func(c *qt.C) {
+		c.Setenv(envName, "new value")
+		c.Check(os.Getenv(envName), qt.Equals, "new value")
+	})
+	_, ok := os.LookupEnv(envName)
+	c.Assert(ok, qt.Equals, false)
+}
+
+func TestUnsetenv(t *testing.T) {
+	c := qt.New(t)
+	const envName = "SOME_VAR"
+	os.Setenv(envName, "initial")
+	testDefer(c, func(c *qt.C) {
+		c.Unsetenv(envName)
+		_, ok := os.LookupEnv(envName)
+		c.Assert(ok, qt.Equals, false)
+	})
+	c.Check(os.Getenv(envName), qt.Equals, "initial")
+}
+
+func TestUnsetenvWithUnsetVariable(t *testing.T) {
+	c := qt.New(t)
+	const envName = "SOME_VAR"
+	os.Unsetenv(envName)
+	testDefer(c, func(c *qt.C) {
+		c.Unsetenv(envName)
+		_, ok := os.LookupEnv(envName)
+		c.Assert(ok, qt.Equals, false)
+	})
+	_, ok := os.LookupEnv(envName)
+	c.Assert(ok, qt.Equals, false)
+}
+
 func TestMkdir(t *testing.T) {
 	c := qt.New(t)
 	var dir string


### PR DESCRIPTION
Currently calling `c.Setenv` has a visible side-effect if the variable was previously unset, and there's no way to unset an environment variable. We fix the former issue and implement `C.Unsetenv` to address the latter.