### PR TITLE
make IsNil guard against nil underlying errors

### DIFF
--- a/checker_test.go
+++ b/checker_test.go
@@ -1327,12 +1327,12 @@ got:
   []int(nil)
 `,
 }, {
-	about:   "IsNil: error does not guard against nil",
+	about:   "IsNil: nil error-implementing type",
 	checker: qt.IsNil,
 	got:     (*errTest)(nil),
-	expectedNegateFailure: `
+	expectedCheckFailure: `
 error:
-  unexpected success
+  error containing nil value of type *quicktest_test.errTest. See https://golang.org/doc/faq#nil_error
 got:
   e<nil>
 `,

--- a/doc.go
+++ b/doc.go
@@ -141,6 +141,14 @@ For example:
 	c.Assert("hello world", qt.Contains, "world")
 	c.Assert([]int{3,5,7,99}, qt.Contains, 7)
 
+ContentEquals
+
+ContentEquals is is like DeepEquals but any slices in the compared values will be sorted before being compared.
+
+For example:
+
+	c.Assert([]string{"c", "a", "b"}, qt.ContentEquals, []string{"a", "b", "c"})
+
 DeepEquals
 
 DeepEquals checks that two arbitrary values are deeply equal.
@@ -191,6 +199,16 @@ IsNil checks that the provided value is nil.
 For instance:
 
     c.Assert(got, qt.IsNil)
+
+As a special case, if the value is nil but implements the
+error interface, it is still considered to be non-nil.
+This means that IsNil will fail on an error value that happens
+to have an underlying nil value, because that's
+invariably a mistake. See https://golang.org/doc/faq#nil_error.
+
+So it's just fine to check an error like this:
+
+    c.Assert(err, qt.IsNil)
 
 JSONEquals
 


### PR DESCRIPTION
Almost everyone that uses quicktest for the first time uses
IsNil to check for errors, but there's a subtle mistake in doing so
because an error with a nil underlying value is not considered
to be nil for the usual `err != nil` error checking.

This change alters the semantics of `IsNil` to guard against
this case. If you really do want to check that a error-implementing
value is nil, you can still use qt.Equals.

Also add package-level docs for ContentEquals.
