### PR TITLE
quicktest: Mkdir log on failure instead of using Check

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -72,8 +72,12 @@ func (c *C) Mkdir() string {
 	name, err := ioutil.TempDir("", "quicktest-")
 	c.Assert(err, Equals, nil)
 	c.cleanup(func() {
-		err := os.RemoveAll(name)
-		c.Check(err, Equals, nil)
+		if err := os.RemoveAll(name); err != nil {
+			// Don't call c.Check because the stack traverse logic won't
+			// print the source location, so just log instead.
+			c.Logf("quicktest cannot remove temporary testing directory: %v", err)
+			c.Fail()
+		}
 	})
 	return name
 }


### PR DESCRIPTION
If the directory removal fails, the stack traversal logic (which
removes all entries below the quicktest package) won't
print any entries in the stack, which can be confusing.

We work around that by just logging a somewhat more informative
error message and avoiding calling Check.