### PR TITLE
Update go-cmp dependency to v0.5.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/frankban/quicktest
 
 require (
-	github.com/google/go-cmp v0.4.0
+	github.com/google/go-cmp v0.5.2
 	github.com/kr/pretty v0.2.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
-github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/report_test.go
+++ b/report_test.go
@@ -92,29 +92,22 @@ func TestCmpReportOutput(t *testing.T) {
 	tt := &testingT{}
 	c := qt.New(tt)
 	gotExamples := []*reportExample{{
-		AnInt:  42,
-		ASlice: []string{},
+		AnInt: 42,
 	}, {
-		AnInt:  47,
-		ASlice: []string{"these", "are", "the", "voyages"},
+		AnInt: 47,
 	}, {
 		AnInt: 1,
 	}, {
 		AnInt: 2,
-	}, {
-		ASlice: []string{"foo", "bar"},
 	}}
 	wantExamples := []*reportExample{{
 		AnInt: 42,
 	}, {
-		AnInt:  47,
-		ASlice: []string{"these", "are", "the", "voyages"},
+		AnInt: 47,
 	}, {
 		AnInt: 2,
 	}, {
 		AnInt: 1,
-	}, {
-		ASlice: []string{"foo"},
 	}, {}}
 	checker := qt.WithVerbosity(qt.DeepEquals, false)
 	c.Assert(gotExamples, checker, wantExamples)
@@ -123,26 +116,15 @@ error:
   values are not deep equal
 diff (-got +want):
     []*quicktest_test.reportExample{
-            &{
-                    AnInt:  42,
-  -                 ASlice: []string{},
-  +                 ASlice: nil,
-            },
-            &{AnInt: 47, ASlice: []string{"these", "are", "the", "voyages"}},
+            &{AnInt: 42},
+            &{AnInt: 47},
   +         &{AnInt: 2},
             &{AnInt: 1},
   -         &{AnInt: 2},
-            &{
-                    AnInt: 0,
-                    ASlice: []string{
-                            "foo",
-  -                         "bar",
-                    },
-            },
   +         &{},
     }
 stack:
-  $file:120
+  $file:113
     c.Assert(gotExamples, checker, wantExamples)
 `
 	assertReport(t, tt, want)
@@ -168,6 +150,5 @@ func assertReport(t *testing.T, tt *testingT, want string) {
 }
 
 type reportExample struct {
-	AnInt  int
-	ASlice []string
+	AnInt int
 }


### PR DESCRIPTION
To do that, simplify the cmp report test, which is not really required to be comprehensive, as its goal is to show that the diff is displayed sanely, not that the diff itself is correct.

Fixes https://github.com/frankban/quicktest/issues/74
