### PR TITLE
report: print frames for exported quicktest API calls

### DIFF
--- a/quicktest.go
+++ b/quicktest.go
@@ -19,6 +19,7 @@ import (
 // Additional args (not consumed by the checker), when provided, are included as
 // comments in the failure output when the check fails.
 func Check(t testing.TB, got interface{}, checker Checker, args ...interface{}) bool {
+	t.Helper()
 	return New(t).Check(got, checker, args...)
 }
 
@@ -31,6 +32,7 @@ func Check(t testing.TB, got interface{}, checker Checker, args ...interface{}) 
 // Additional args (not consumed by the checker), when provided, are included as
 // comments in the failure output when the check fails.
 func Assert(t testing.TB, got interface{}, checker Checker, args ...interface{}) bool {
+	t.Helper()
 	return New(t).Assert(got, checker, args...)
 }
 
@@ -183,9 +185,9 @@ func (c *C) getFormat() func(interface{}) string {
 // Additional args (not consumed by the checker), when provided, are included
 // as comments in the failure output when the check fails.
 func (c *C) Check(got interface{}, checker Checker, args ...interface{}) bool {
-	return check(checkParams{
+	c.TB.Helper()
+	return check(c, checkParams{
 		fail:    c.TB.Error,
-		format:  c.getFormat(),
 		checker: checker,
 		got:     got,
 		args:    args,
@@ -201,9 +203,9 @@ func (c *C) Check(got interface{}, checker Checker, args ...interface{}) bool {
 // Additional args (not consumed by the checker), when provided, are included
 // as comments in the failure output when the check fails.
 func (c *C) Assert(got interface{}, checker Checker, args ...interface{}) bool {
-	return check(checkParams{
+	c.TB.Helper()
+	return check(c, checkParams{
 		fail:    c.TB.Fatal,
-		format:  c.getFormat(),
 		checker: checker,
 		got:     got,
 		args:    args,
@@ -294,11 +296,12 @@ func (c *C) Parallel() {
 // check performs the actual check with the provided params.
 // In case of failure p.fail is called. In the fail report values are formatted
 // using p.format.
-func check(p checkParams) bool {
+func check(c *C, p checkParams) bool {
+	c.TB.Helper()
 	rp := reportParams{
 		got:    p.got,
 		args:   p.args,
-		format: p.format,
+		format: c.getFormat(),
 	}
 	if rp.format == nil {
 		// No format set; use the default: Format.
@@ -354,7 +357,6 @@ func check(p checkParams) bool {
 // checkParams holds parameters for executing a check.
 type checkParams struct {
 	fail    func(...interface{})
-	format  formatFunc
 	checker Checker
 	got     interface{}
 	args    []interface{}

--- a/report.go
+++ b/report.go
@@ -13,7 +13,6 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
-	"unicode"
 )
 
 // reportParams holds parameters for reporting a test error.
@@ -117,8 +116,8 @@ func writeStack(w io.Writer) {
 			// Stop before getting back to stdlib test runner calls.
 			break
 		}
-		if strings.HasPrefix(frame.Function, thisPackage) {
-			if r := rune(frame.Function[len(thisPackage)]); unicode.IsUpper(r) {
+		if fname := strings.TrimPrefix(frame.Function, thisPackage); fname != frame.Function {
+			if ast.IsExported(fname) {
 				// Continue without printing frames for quicktest exported API.
 				continue
 			}

--- a/report_test.go
+++ b/report_test.go
@@ -130,6 +130,23 @@ stack:
 	assertReport(t, tt, want)
 }
 
+func TestTopLevelAssertReportOutput(t *testing.T) {
+	tt := &testingT{}
+	qt.Assert(tt, 42, qt.Equals, 47)
+	want := `
+error:
+  values are not equal
+got:
+  int(42)
+want:
+  int(47)
+stack:
+  $file:135
+    qt.Assert(tt, 42, qt.Equals, 47)
+`
+	assertReport(t, tt, want)
+}
+
 func assertReport(t *testing.T, tt *testingT, want string) {
 	got := strings.Replace(tt.fatalString(), "\t", "        ", -1)
 	// go-cmp can include non-breaking spaces in its output.


### PR DESCRIPTION
Also call TB.Helper internally, in order to print a more useful file:line message in failures output.

Fixes https://github.com/frankban/quicktest/issues/79
Fixes https://github.com/frankban/quicktest/issues/80