### PR TITLE
Add Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: go
 go_import_path: github.com/frankban/quicktest
 
+arch:
+  - amd64
+  - ppc64le
+  
 go:
   - "1.11.x"
   - "1.12.x"
@@ -9,6 +13,11 @@ go:
   - "1.15.x"
   - 1.x
   - master
+
+jobs:
+ exclude:
+  - arch: ppc64le
+    go: master
 
 script:
   - GO111MODULE=on go test -race ./...


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. Thanks.