### PR TITLE
don't try to print non-Go source files

### DIFF
--- a/report.go
+++ b/report.go
@@ -126,11 +126,13 @@ func writeStack(w io.Writer) {
 			break
 		}
 		fmt.Fprint(w, prefixf(prefix, "%s:%d", frame.File, frame.Line))
-		stmt, err := sg.Get(frame.File, frame.Line)
-		if err != nil {
-			fmt.Fprint(w, prefixf(prefix+prefix, "<%s>", err))
-		} else {
-			fmt.Fprint(w, prefixf(prefix+prefix, "%s", stmt))
+		if strings.HasSuffix(frame.File, ".go") {
+			stmt, err := sg.Get(frame.File, frame.Line)
+			if err != nil {
+				fmt.Fprint(w, prefixf(prefix+prefix, "<%s>", err))
+			} else {
+				fmt.Fprint(w, prefixf(prefix+prefix, "%s", stmt))
+			}
 		}
 		if !more {
 			// There are no more callers.


### PR DESCRIPTION
Fixes #86.

Unfortunately it's not entirely clear how to write a good test for this,
but the additional logic is simple enough that it probably doesn't
really need one.