### PR TITLE
Equals: show multi-line strings diff

### DIFF
--- a/.godocdown.template
+++ b/.godocdown.template
@@ -10,4 +10,4 @@
 {{ .EmitSynopsis }}
 
 For a complete API reference, see the
-[package documentation](https://godoc.org/github.com/frankban/quicktest).
+[package documentation](https://pkg.go.dev/github.com/frankban/quicktest).

--- a/README.md
+++ b/README.md
@@ -315,4 +315,4 @@ The c.Patch, c.Setenv, c.Unsetenv and c.Mkdir helpers use t.Cleanup for cleaning
 up resources when available, and fall back to Defer otherwise.
 
 For a complete API reference, see the
-[package documentation](https://godoc.org/github.com/frankban/quicktest).
+[package documentation](https://pkg.go.dev/github.com/frankban/quicktest).

--- a/checker.go
+++ b/checker.go
@@ -90,13 +90,12 @@ func (c *equalsChecker) Check(got interface{}, args []interface{}, note func(key
 	// Show line diff when comparing different multi-line strings.
 	if got, ok := got.(string); ok {
 		if want, ok := want.(string); ok {
-			isMultiline := func(s []string) bool {
-				return len(s) > 2 || (len(s) == 2 && s[1] != "")
+			isMultiLine := func(s string) bool {
+				i := strings.Index(s, "\n")
+				return i != -1 && i < len(s)-1
 			}
-			gotLines := strings.SplitAfter(got, "\n")
-			wantLines := strings.SplitAfter(want, "\n")
-			if isMultiline(gotLines) || isMultiline(wantLines) {
-				diff := cmp.Diff(gotLines, wantLines)
+			if isMultiLine(got) || isMultiLine(want) {
+				diff := cmp.Diff(strings.SplitAfter(got, "\n"), strings.SplitAfter(want, "\n"))
 				note("line diff (-got +want)", Unquoted(diff))
 			}
 		}

--- a/checker.go
+++ b/checker.go
@@ -64,13 +64,44 @@ func (c *equalsChecker) Check(got interface{}, args []interface{}, note func(key
 			err = fmt.Errorf("%s", r)
 		}
 	}()
-	if want := args[0]; got != want {
-		if _, ok := got.(error); ok && want == nil {
-			return errors.New("got non-nil error")
+	want := args[0]
+	if got == want {
+		return nil
+	}
+
+	// Customize error message for non-nil errors.
+	if _, ok := got.(error); ok && want == nil {
+		return errors.New("got non-nil error")
+	}
+
+	// Show error types when comparing errors with different types.
+	if got, ok := got.(error); ok {
+		if want, ok := want.(error); ok {
+			gotType := reflect.TypeOf(got)
+			wantType := reflect.TypeOf(want)
+			if gotType != wantType {
+				note("got type", Unquoted(gotType.String()))
+				note("want type", Unquoted(wantType.String()))
+			}
 		}
 		return errors.New("values are not equal")
 	}
-	return nil
+
+	// Show line diff when comparing different multi-line strings.
+	if got, ok := got.(string); ok {
+		if want, ok := want.(string); ok {
+			isMultiline := func(s []string) bool {
+				return len(s) > 2 || (len(s) == 2 && s[1] != "")
+			}
+			gotLines := strings.SplitAfter(got, "\n")
+			wantLines := strings.SplitAfter(want, "\n")
+			if isMultiline(gotLines) || isMultiline(wantLines) {
+				diff := cmp.Diff(gotLines, wantLines)
+				note("line diff (-got +want)", Unquoted(diff))
+			}
+		}
+	}
+	return errors.New("values are not equal")
 }
 
 // CmpEquals returns a Checker checking equality of two arbitrary values

--- a/checker_test.go
+++ b/checker_test.go
@@ -5,6 +5,7 @@ package quicktest_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -104,6 +105,47 @@ want:
   ~string "bar"~
 `),
 }, {
+	about:   "Equals: same multiline strings",
+	checker: qt.Equals,
+	got:     "a\nmultiline\nstring",
+	args:    []interface{}{"a\nmultiline\nstring"},
+	expectedNegateFailure: `
+error:
+  unexpected success
+got:
+  "a\nmultiline\nstring"
+want:
+  <same as "got">
+`,
+}, {
+	about:   "Equals: different multi-line strings",
+	checker: qt.Equals,
+	got:     "a\nlong\nmultiline\nstring",
+	args:    []interface{}{"just\na\nlong\nmulti-line\nstring\n"},
+	expectedCheckFailure: fmt.Sprintf(`
+error:
+  values are not equal
+line diff (-got +want):
+%s
+got:
+  "a\nlong\nmultiline\nstring"
+want:
+  "just\na\nlong\nmulti-line\nstring\n"
+`, diff([]string{"a\n", "long\n", "multiline\n", "string"}, []string{"just\n", "a\n", "long\n", "multi-line\n", "string\n", ""})),
+}, {
+	about:   "Equals: different single-line strings ending with newline",
+	checker: qt.Equals,
+	got:     "foo\n",
+	args:    []interface{}{"bar\n"},
+	expectedCheckFailure: `
+error:
+  values are not equal
+got:
+  "foo\n"
+want:
+  "bar\n"
+`,
+}, {
 	about:   "Equals: different types",
 	checker: qt.Equals,
 	got:     42,
@@ -186,6 +228,25 @@ got:
 want:
   nil
 `),
+}, {
+	about:   "Equals: different errors with same message",
+	checker: qt.Equals,
+	got: &errTest{
+		msg: "bad wolf",
+	},
+	args: []interface{}{errors.New("bad wolf")},
+	expectedCheckFailure: `
+error:
+  values are not equal
+got type:
+  *quicktest_test.errTest
+want type:
+  *errors.errorString
+got:
+  e"bad wolf"
+want:
+  <same as "got">
+`,
 }, {
 	about:   "Equals: nil struct",
 	checker: qt.Equals,

--- a/checker_test.go
+++ b/checker_test.go
@@ -146,6 +146,21 @@ want:
   "bar\n"
 `,
 }, {
+	about:   "Equals: different strings starting with newline",
+	checker: qt.Equals,
+	got:     "\nfoo",
+	args:    []interface{}{"\nbar"},
+	expectedCheckFailure: fmt.Sprintf(`
+error:
+  values are not equal
+line diff (-got +want):
+%s
+got:
+  "\nfoo"
+want:
+  "\nbar"
+`, diff([]string{"\n", "foo"}, []string{"\n", "bar"})),
+}, {
 	about:   "Equals: different types",
 	checker: qt.Equals,
 	got:     42,

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/frankban/quicktest
 
 require (
-	github.com/google/go-cmp v0.5.4
+	github.com/google/go-cmp v0.5.5
 	github.com/kr/pretty v0.2.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
-github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=


### PR DESCRIPTION
It is possible to leverage go-cmp to show line diff when comparing two long strings, lilke:
```
error:
  values are not equal
line diff (-got +want):
    []string{
  +         "just\n",
            "another\n",
            "long\n",
  -         "multiline\n",
  +         "multi-line\n",
  -         "string",
  +         "string\n",
  +         "",
    }
got:
  "another\nlong\nmultiline\nstring"
want:
  "just\nanother\nlong\nmulti-line\nstring\n"
```
I think this can help spotting differences especially when they are subtle.

Also, sometimes when comparing two errors (for instance when checking causes), a confusing failure message can be returned in case the two errors return the same message:
```
error:
  values are not equal
got:
  e"bad wolf"
want:
  <same as "got">
```
In this cases showing the error types helps understanding the actual issue.

