### PR TITLE
Issues/92: format uint types, using decimal notation.

### DIFF
--- a/format.go
+++ b/format.go
@@ -35,6 +35,8 @@ func Format(v interface{}) string {
 		return "s" + quoteString(s)
 	case string:
 		return quoteString(v)
+	case uint64:
+		return fmt.Sprintf("%T(%d)", v, v)
 	}
 	if bytes, ok := byteSlice(v); ok && bytes != nil && utf8.Valid(bytes) {
 		// It's a top level slice of bytes that's also valid UTF-8.

--- a/format.go
+++ b/format.go
@@ -35,7 +35,7 @@ func Format(v interface{}) string {
 		return "s" + quoteString(s)
 	case string:
 		return quoteString(v)
-	case uint64:
+	case uintptr, uint, uint8, uint16, uint32, uint64:
 		return fmt.Sprintf("%T(%d)", v, v)
 	}
 	if bytes, ok := byteSlice(v); ok && bytes != nil && utf8.Valid(bytes) {

--- a/format.go
+++ b/format.go
@@ -36,6 +36,7 @@ func Format(v interface{}) string {
 	case string:
 		return quoteString(v)
 	case uintptr, uint, uint8, uint16, uint32, uint64:
+		// Use decimal base (rather than hexadecimal) for representing uint types.
 		return fmt.Sprintf("%T(%d)", v, v)
 	}
 	if bytes, ok := byteSlice(v); ok && bytes != nil && utf8.Valid(bytes) {

--- a/format_test.go
+++ b/format_test.go
@@ -108,7 +108,12 @@ var formatTests = []struct {
 	about: "struct with byte slice",
 	value: struct{ X []byte }{[]byte("x")},
 	want:  "struct { X []uint8 }{\n    X:  {0x78},\n}",
-}}
+}, {
+	about: "uint64",
+	value: uint64(17),
+	want:  "uint64(17)",
+},
+}
 
 func TestFormat(t *testing.T) {
 	for _, test := range formatTests {

--- a/format_test.go
+++ b/format_test.go
@@ -112,17 +112,15 @@ var formatTests = []struct {
 	about: "uint64",
 	value: uint64(17),
 	want:  "uint64(17)",
+}, {
+	about: "uint32",
+	value: uint32(17_898),
+	want:  "uint32(17898)",
+}, {
+	about: "uintptr",
+	value: uintptr(13),
+	want:  "uintptr(13)",
 },
-	{
-		about: "uint32",
-		value: uint32(17_898),
-		want:  "uint32(17898)",
-	},
-	{
-		about: "uintptr",
-		value: uintptr(13),
-		want:  "uintptr(13)",
-	},
 }
 
 func TestFormat(t *testing.T) {

--- a/format_test.go
+++ b/format_test.go
@@ -114,7 +114,7 @@ var formatTests = []struct {
 	want:  "uint64(17)",
 }, {
 	about: "uint32",
-	value: uint32(17_898),
+	value: uint32(17898),
 	want:  "uint32(17898)",
 }, {
 	about: "uintptr",

--- a/format_test.go
+++ b/format_test.go
@@ -113,6 +113,16 @@ var formatTests = []struct {
 	value: uint64(17),
 	want:  "uint64(17)",
 },
+	{
+		about: "uint32",
+		value: uint32(17_898),
+		want:  "uint32(17898)",
+	},
+	{
+		about: "uintptr",
+		value: uintptr(13),
+		want:  "uintptr(13)",
+	},
 }
 
 func TestFormat(t *testing.T) {


### PR DESCRIPTION
What:
- format uint types, using the type plus the decimal notation.

Why:
- Previously, numbers like `uint64(17)` would get formatted in hex as `uint64(0x11)`
   This would make it hard to visually compare the `got` & `want` values when a test failed.
- Fixes: https://github.com/frankban/quicktest/issues/92