### PR TITLE
update CI badges

### DIFF
--- a/.godocdown.template
+++ b/.godocdown.template
@@ -1,5 +1,5 @@
 [![GoDoc](https://godoc.org/github.com/frankban/quicktest?status.svg)](https://godoc.org/github.com/frankban/quicktest)
-[![Build Status](https://travis-ci.com/frankban/quicktest.svg?branch=master)](https://travis-ci.com/frankban/quicktest)
+[![Build Status](https://github.com/frankban/quicktest/actions/workflows/ci.yaml/badge.svg)](https://github.com/frankban/quicktest/actions/workflows/ci.yaml)
 
 [//]: # (Generated with: godocdown -template=.godocdown.template -o README.md)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![GoDoc](https://godoc.org/github.com/frankban/quicktest?status.svg)](https://godoc.org/github.com/frankban/quicktest)
-[![Build Status](https://travis-ci.com/frankban/quicktest.svg?branch=master)](https://travis-ci.com/frankban/quicktest)
+[![Build Status](https://github.com/frankban/quicktest/actions/workflows/ci.yaml/badge.svg)](https://github.com/frankban/quicktest/actions/workflows/ci.yaml)
 
 [//]: # (Generated with: godocdown -template=.godocdown.template -o README.md)
 


### PR DESCRIPTION
After changing the CI infrastructure to github actions the badges in
the README are out of date.