### PR TITLE
Add ErrorAs and ErrorIs checkers

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,16 @@ Note that the following will fail:
 Use the IsNil checker below for this kind of nil check.
 
 
+### ErrorIs
+
+ErrorIs is a Checker checking that the error is or wraps the provided error.
+This is analogous to calling errors.Is.
+
+For instance:
+
+    c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+
+
 ### ErrorMatches
 
 ErrorMatches checks that the provided value is an error whose message matches

--- a/README.md
+++ b/README.md
@@ -166,6 +166,17 @@ Note that the following will fail:
 Use the IsNil checker below for this kind of nil check.
 
 
+### ErrorAs
+
+ErrorAs is a Checker checking that the error is or wraps the provided error and
+if so, assigns it to the pointer. This is analogous to calling errors.As.
+
+For instance:
+
+    var pathError *os.PathError
+    c.Assert(err, qt.ErrorAs, &pathError)
+
+
 ### ErrorIs
 
 ErrorIs is a Checker checking that the error is or wraps the provided error.

--- a/checker_test.go
+++ b/checker_test.go
@@ -971,6 +971,96 @@ want args:
   regexp
 `,
 }, {
+	about:   "ErrorIs: exact match",
+	checker: qt.ErrorIs,
+	got:     error(errBadWolf),
+	args:    []interface{}{errBadWolf},
+	expectedNegateFailure: `
+error:
+  unexpected success
+got:
+  bad wolf
+    file:line
+want:
+  <same as "got">
+`,
+}, {
+	about:   "ErrorIs: wrapped match",
+	checker: qt.ErrorIs,
+	got:     fmt.Errorf("wrapped: %w", error(errBadWolf)),
+	args:    []interface{}{errBadWolf},
+	expectedNegateFailure: `
+error:
+  unexpected success
+got:
+  e"wrapped: bad wolf\n  file:line"
+want:
+  bad wolf
+    file:line
+`,
+}, {
+	about:   "ErrorIs: fails if nil error",
+	checker: qt.ErrorIs,
+	got:     nil,
+	args:    []interface{}{errBadWolf},
+	expectedCheckFailure: `
+error:
+  got nil error but want non-nil
+got:
+  nil
+want:
+  bad wolf
+    file:line
+`,
+}, {
+	about:   "ErrorIs: fails if mismatch",
+	checker: qt.ErrorIs,
+	got:     error(errBadWolf),
+	args:    []interface{}{errors.New("other error")},
+	expectedCheckFailure: `
+error:
+  error is not the expected error
+got:
+  bad wolf
+    file:line
+want:
+  e"other error"
+`,
+}, {
+	about:   "ErrorIs: bad check if invalid error",
+	checker: qt.ErrorIs,
+	got:     "not an error",
+	args:    []interface{}{errBadWolf},
+	expectedCheckFailure: `
+error:
+  bad check: first argument is not an error
+got:
+  "not an error"
+`,
+	expectedNegateFailure: `
+error:
+  bad check: first argument is not an error
+got:
+  "not an error"
+`,
+}, {
+	about:   "ErrorIs: bad check if invalid error value",
+	checker: qt.ErrorIs,
+	got:     errBadWolf,
+	args:    []interface{}{"not an error"},
+	expectedCheckFailure: `
+error:
+  bad check: value is not an error
+want:
+  "not an error"
+`,
+	expectedNegateFailure: `
+error:
+  bad check: value is not an error
+want:
+  "not an error"
+`,
+}, {
 	about:   "ErrorMatches: perfect match",
 	checker: qt.ErrorMatches,
 	got:     errBadWolf,

--- a/error_test.go
+++ b/error_test.go
@@ -43,7 +43,7 @@ func (err *errTest) Error() string {
 
 // Format implements fmt.Formatter.
 func (err *errTest) Format(f fmt.State, c rune) {
-	if !f.Flag('+') || c != 'v' {
+	if c != 'v' {
 		fmt.Fprint(f, "unexpected verb for formatting the error")
 	}
 	fmt.Fprint(f, err.Error())


### PR DESCRIPTION
The `ErrorAs` and `ErrorIs` checkers provide convenient ways for working with wrapped errors. They allow test authors to make assertions about errors anywhere in the chain of wrapped errors. Any error that supports the `Unwrap() error` method is supported, such as those returned by `fmt.Errorf()` or the `github.com/pkg/errors` package.

Example `ErrorAs` usage:

    var customError CustomError
    if c.Check(err, qt.ErrorAs, &customError) {
        c.Assert(customError.Something, …)
    }

Example `ErrorIs` usage:

    c.Assert(err, qt.ErrorIs, os.ErrNotExist)

The initial discussion for this was in #109.