### PR TITLE
Add Implements checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,16 @@ For instance:
     c.Assert(myMap, qt.HasLen, 42)
 
 
+### Implements
+
+Implements checks that the provided value implements the given interface. A
+pointer to the interface must be provided.
+
+For instance:
+
+    c.Assert(myReader, qt.Implements, io.ReadCloser)
+
+
 ### IsFalse
 
 IsFalse checks that the provided value is false. The value must have a boolean

--- a/checker_test.go
+++ b/checker_test.go
@@ -17,6 +17,11 @@ import (
 	qt "github.com/frankban/quicktest"
 )
 
+// Fooer is an interface for testing.
+type Fooer interface {
+	Foo()
+}
+
 var (
 	goTime = time.Date(2012, 3, 28, 0, 0, 0, 0, time.UTC)
 	chInt  = func() chan int {
@@ -1713,6 +1718,92 @@ got args:
   }
 want args:
   want length
+`,
+}, {
+	about:   "Implements: implements interface",
+	checker: qt.Implements,
+	got:     errBadWolf,
+	args:    []interface{}{(*error)(nil)},
+	expectedNegateFailure: `
+error:
+  unexpected success
+got:
+  bad wolf
+    file:line
+want:
+  (*error)(nil)
+`,
+}, {
+	about:   "Implements: does not implement interface",
+	checker: qt.Implements,
+	got:     errBadWolf,
+	args:    []interface{}{(*Fooer)(nil)},
+	expectedCheckFailure: `
+error:
+  got value does not implement wanted interface
+got:
+  bad wolf
+    file:line
+want type:
+  "quicktest_test.Fooer"
+`,
+}, {
+	about:   "Implements: fails if got nil",
+	checker: qt.Implements,
+	got:     nil,
+	args:    []interface{}{(*Fooer)(nil)},
+	expectedCheckFailure: `
+error:
+  got nil value but want non-nil
+got:
+  nil
+`,
+}, {
+	about:   "Implements: bad check if wanted is nil",
+	checker: qt.Implements,
+	got:     errBadWolf,
+	args:    []interface{}{nil},
+	expectedCheckFailure: `
+error:
+  bad check: wanted value is nil but must be non-nil
+`,
+	expectedNegateFailure: `
+error:
+  bad check: wanted value is nil but must be non-nil
+`,
+}, {
+	about:   "Implements: bad check if wanted is not pointer",
+	checker: qt.Implements,
+	got:     errBadWolf,
+	args:    []interface{}{struct{}{}},
+	expectedCheckFailure: `
+error:
+  bad check: wanted value must be a pointer to an interface
+want:
+  "struct {}"
+`,
+	expectedNegateFailure: `
+error:
+  bad check: wanted value must be a pointer to an interface
+want:
+  "struct {}"
+`,
+}, {
+	about:   "Implements: bad check if wanted is not pointer to interface",
+	checker: qt.Implements,
+	got:     errBadWolf,
+	args:    []interface{}{&struct{}{}},
+	expectedCheckFailure: `
+error:
+  bad check: wanted value must be a pointer to an interface
+want:
+  "*struct {}"
+`,
+	expectedNegateFailure: `
+error:
+  bad check: wanted value must be a pointer to an interface
+want:
+  "*struct {}"
 `,
 }, {
 	about:   "Satisfies: success with an error",


### PR DESCRIPTION
The `Implements` checker provides a simple way to check whether a particular value's type implements a given interface. It is required to provide the interface to check via a pointer (due to some limitations of how `reflect` interacts with interfaces).

Example usage:

    c.Assert(myReader, qt.Implements, io.ReadCloser)