### PR TITLE
Fix ErrorIs for nil values

### DIFF
--- a/checker_go1.13.go
+++ b/checker_go1.13.go
@@ -70,13 +70,16 @@ type errorIsChecker struct {
 // Check implements Checker.Check by checking that got is an error whose error
 // chain matches args[0].
 func (c *errorIsChecker) Check(got interface{}, args []interface{}, note func(key string, value interface{})) error {
+	if got == nil && args[0] == nil {
+		return nil
+	}
 	if err := checkFirstArgIsError(got, note); err != nil {
 		return err
 	}
 
 	gotErr := got.(error)
 	wantErr, ok := args[0].(error)
-	if !ok {
+	if !ok && args[0] != nil {
 		note("want", args[0])
 		return BadCheckf("second argument is not an error")
 	}

--- a/checker_go1.13_test.go
+++ b/checker_go1.13_test.go
@@ -119,6 +119,32 @@ error:
   bad check: errors: *target must be interface or implement error
 `,
 }, {
+	about:   "ErrorIs: nil to nil match",
+	checker: qt.ErrorIs,
+	got:     nil,
+	args:    []interface{}{nil},
+	expectedNegateFailure: `
+error:
+  unexpected success
+got:
+  nil
+want:
+  <same as "got">
+`,
+}, {
+	about:   "ErrorIs: non-nil to nil match",
+	checker: qt.ErrorIs,
+	got:     targetErr,
+	args:    []interface{}{nil},
+	expectedCheckFailure: `
+error:
+  wanted error is not found in error chain
+got:
+  e"target"
+want:
+  nil
+`,
+}, {
 	about:   "ErrorIs: exact match",
 	checker: qt.ErrorIs,
 	got:     targetErr,


### PR DESCRIPTION
If both the LHS and the RHS are nil,
then ErrorIs should treat them as equal.

For example: `c.Assert(nil, qt.ErrorIs, nil)` should succeed.

If the LHS is non-nil, and the RHS is nil,
then ErrorIs should treat the RHS as an error.

For example: `c.Assert(io.EOF, qt.ErrorIs, nil)` should fail
due to `io.EOF` not being part of the error chain of nil,
rather than nil not being a valid error value.