### PR TITLE
Allow Matches and ErrorMatches matches to use an already-compiled regexp.Regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ the provided regular expression.
 For instance:
 
     c.Assert(err, qt.ErrorMatches, `bad wolf .*`)
+    c.Assert(err, qt.ErrorMatches, regexp.MustCompile("bad wolf .*"))
 
 
 ### HasLen
@@ -301,6 +302,7 @@ For instance:
 
     c.Assert("these are the voyages", qt.Matches, `these are .*`)
     c.Assert(net.ParseIP("1.2.3.4"), qt.Matches, `1.*`)
+    c.Assert("line 1\nline 2", qt.Matches, regexp.MustCompile(`line \d\nline \d`))
 
 
 ### Not
@@ -321,6 +323,7 @@ the provided regular expression.
 For instance:
 
     c.Assert(func() {panic("bad wolf ...")}, qt.PanicMatches, `bad wolf .*`)
+    c.Assert(func() {panic("bad wolf ...")}, qt.PanicMatches, regexp.MustCompile(`bad wolf .*`))
 
 
 ### Satisfies

--- a/checker.go
+++ b/checker.go
@@ -170,6 +170,7 @@ var ContentEquals = CmpEquals(cmpopts.SortSlices(func(x, y interface{}) bool {
 //
 //	c.Assert("these are the voyages", qt.Matches, "these are .*")
 //	c.Assert(net.ParseIP("1.2.3.4"), qt.Matches, "1.*")
+//	c.Assert("my multi-line\nnumber", qt.Matches, regexp.MustCompile(`my multi-line\n(string|number)`))
 var Matches Checker = &matchesChecker{
 	argNames: []string{"got value", "regexp"},
 }
@@ -210,6 +211,7 @@ func checkFirstArgIsError(got interface{}, note func(key string, value interface
 // For instance:
 //
 //	c.Assert(err, qt.ErrorMatches, "bad wolf .*")
+//	c.Assert(err, qt.ErrorMatches, regexp.MustCompile("bad wolf .*"))
 var ErrorMatches Checker = &errorMatchesChecker{
 	argNames: []string{"got error", "regexp"},
 }
@@ -235,6 +237,7 @@ func (c *errorMatchesChecker) Check(got interface{}, args []interface{}, note fu
 // For instance:
 //
 //	c.Assert(func() {panic("bad wolf ...")}, qt.PanicMatches, "bad wolf .*")
+//	c.Assert(func() {panic("bad wolf ...")}, qt.PanicMatches, regexp.MustCompile(`bad wolf .*`))
 var PanicMatches Checker = &panicMatchesChecker{
 	argNames: []string{"function", "regexp"},
 }

--- a/checker.go
+++ b/checker.go
@@ -766,6 +766,12 @@ func (a argNames) ArgNames() []string {
 
 // match checks that the given error message matches the given pattern.
 func match(got string, pattern interface{}, msg string, note func(key string, value interface{})) error {
+	if actualRegex, ok := pattern.(*regexp.Regexp); ok {
+		if actualRegex.MatchString(got) {
+			return nil
+		}
+		return errors.New(msg)
+	}
 	regex, ok := pattern.(string)
 	if !ok {
 		note("regexp", pattern)

--- a/checker_test.go
+++ b/checker_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -936,6 +937,45 @@ got value:
   "these are the voyages"
 regexp:
   "these are the .*"
+`,
+}, {
+	about:   "Matches: match with pre-compiled regexp",
+	checker: qt.Matches,
+	got:     bytes.NewBufferString("resistance is futile"),
+	args:    []interface{}{regexp.MustCompile("resistance is (futile|useful)")},
+	expectedNegateFailure: `
+error:
+  unexpected success
+got value:
+  s"resistance is futile"
+regexp:
+  s"resistance is (futile|useful)"
+`,
+}, {
+	about:   "Matches: mismatch with pre-compiled regexp",
+	checker: qt.Matches,
+	got:     bytes.NewBufferString("resistance is cool"),
+	args:    []interface{}{regexp.MustCompile("resistance is (futile|useful)")},
+	expectedCheckFailure: `
+error:
+  value.String() does not match regexp
+got value:
+  s"resistance is cool"
+regexp:
+  s"resistance is (futile|useful)"
+`,
+}, {
+	about:   "Matches: match with pre-compiled multi-line regexp",
+	checker: qt.Matches,
+	got:     bytes.NewBufferString("line 1\nline 2"),
+	args:    []interface{}{regexp.MustCompile(`line \d\nline \d`)},
+	expectedNegateFailure: `
+error:
+  unexpected success
+got value:
+  s"line 1\nline 2"
+regexp:
+  s"line \\d\\nline \\d"
 `,
 }, {
 	about:   "Matches: match with stringer",

--- a/checker_test.go
+++ b/checker_test.go
@@ -1312,6 +1312,49 @@ want args:
   regexp
 `,
 }, {
+	about:   "ErrorMatches: match with pre-compiled regexp",
+	checker: qt.ErrorMatches,
+	got:     errBadWolf,
+	args:    []interface{}{regexp.MustCompile("bad (wolf|dog)")},
+	expectedNegateFailure: `
+error:
+  unexpected success
+got error:
+  bad wolf
+    file:line
+regexp:
+  s"bad (wolf|dog)"
+`,
+}, {
+	about:   "ErrorMatches: match with pre-compiled multi-line regexp",
+	checker: qt.ErrorMatches,
+	got:     errBadWolfMultiLine,
+	args:    []interface{}{regexp.MustCompile(`bad (wolf|dog)\nfaulty (logic|statement)`)},
+	expectedNegateFailure: `
+error:
+  unexpected success
+got error:
+  bad wolf
+  faulty logic
+    file:line
+regexp:
+  s"bad (wolf|dog)\\nfaulty (logic|statement)"
+`,
+}, {
+	about:   "ErrorMatches: mismatch with pre-compiled regexp",
+	checker: qt.ErrorMatches,
+	got:     errBadWolf,
+	args:    []interface{}{regexp.MustCompile("good (wolf|dog)")},
+	expectedCheckFailure: `
+error:
+  error does not match regexp
+got error:
+  bad wolf
+    file:line
+regexp:
+  s"good (wolf|dog)"
+`,
+}, {
 	about:   "PanicMatches: perfect match",
 	checker: qt.PanicMatches,
 	got:     func() { panic("error: bad wolf") },
@@ -1427,6 +1470,51 @@ panic value:
   "error: bad wolf"
 regexp:
   nil
+`,
+}, {
+	about:   "PanicMatches: match with pre-compiled regexp",
+	checker: qt.PanicMatches,
+	got:     func() { panic("error: bad wolf") },
+	args:    []interface{}{regexp.MustCompile("error: bad (wolf|dog)")},
+	expectedNegateFailure: `
+error:
+  unexpected success
+panic value:
+  "error: bad wolf"
+function:
+  func() {...}
+regexp:
+  s"error: bad (wolf|dog)"
+`,
+}, {
+	about:   "PanicMatches: match with pre-compiled multi-line regexp",
+	checker: qt.PanicMatches,
+	got:     func() { panic("error: bad wolf\nfaulty logic") },
+	args:    []interface{}{regexp.MustCompile(`error: bad (wolf|dog)\nfaulty (logic|statement)`)},
+	expectedNegateFailure: `
+error:
+  unexpected success
+panic value:
+  "error: bad wolf\nfaulty logic"
+function:
+  func() {...}
+regexp:
+  s"error: bad (wolf|dog)\\nfaulty (logic|statement)"
+`,
+}, {
+	about:   "PanicMatches: mismatch with pre-compiled regexp",
+	checker: qt.PanicMatches,
+	got:     func() { panic("error: bad wolf") },
+	args:    []interface{}{regexp.MustCompile("good (wolf|dog)")},
+	expectedCheckFailure: `
+error:
+  panic value does not match regexp
+panic value:
+  "error: bad wolf"
+function:
+  func() {...}
+regexp:
+  s"good (wolf|dog)"
 `,
 }, {
 	about:   "PanicMatches: not a function",

--- a/error_test.go
+++ b/error_test.go
@@ -30,6 +30,11 @@ var errBadWolf = &errTest{
 	formatted: true,
 }
 
+var errBadWolfMultiLine = &errTest{
+	msg:       "bad wolf\nfaulty logic",
+	formatted: true,
+}
+
 // errTest is an error type used in tests.
 type errTest struct {
 	msg       string


### PR DESCRIPTION
This allows users to have full control over the regular expression used for matching.

My use-case was matching a multiline string pattern, and the way MatchString was used in the `match`-function made that infeasible.

With this change, I was able to use the Matches matcher like this:

```go
c.Assert("asd\nasd", qt.Matches, regexp.MustCompile(`asd.*`))
```

Happy to update naming of variables on request.
I left naming of parameters/arguments on purpose to keep the diff minimal, but happy to change that too.

As an alternative, if this change is not acceptable, I know I could implement my own Checker handles regular expressions like this, so no worries if this change does not fit into the project!
