### PR TITLE
Improve handling of verbose testing

### DIFF
--- a/checker_test.go
+++ b/checker_test.go
@@ -416,18 +416,6 @@ error:
   values are not deep equal
 diff (-got +want):
 %s
-`, diff(cmpEqualsGot, cmpEqualsWant)),
-}, {
-	about:   "CmpEquals: different values: verbose",
-	checker: qt.CmpEquals(),
-	got:     cmpEqualsGot,
-	args:    []interface{}{cmpEqualsWant},
-	verbose: true,
-	expectedCheckFailure: fmt.Sprintf(`
-error:
-  values are not deep equal
-diff (-got +want):
-%s
 got:
   struct { Strings []interface {}; Ints []int }{
       Strings: {
@@ -445,6 +433,65 @@ want:
       Ints: {42},
   }
 `, diff(cmpEqualsGot, cmpEqualsWant)),
+}, {
+	about:   "CmpEquals: different values, long output",
+	checker: qt.CmpEquals(),
+	got:     []interface{}{cmpEqualsWant, "extra line 1", "extra line 2"},
+	args:    []interface{}{[]interface{}{cmpEqualsWant, "extra line 1"}},
+	expectedCheckFailure: fmt.Sprintf(`
+error:
+  values are not deep equal
+diff (-got +want):
+%s
+got:
+  <suppressed because too long, use -v for the full output>
+want:
+  []interface {}{
+      struct { Strings []interface {}; Ints []int }{
+          Strings: {
+              "who",
+              "dalek",
+          },
+          Ints: {42},
+      },
+      "extra line 1",
+  }
+`, diff([]interface{}{cmpEqualsWant, "extra line 1", "extra line 2"}, []interface{}{cmpEqualsWant, "extra line 1"})),
+}, {
+	about:   "CmpEquals: different values: long output and verbose",
+	checker: qt.CmpEquals(),
+	got:     []interface{}{cmpEqualsWant, "extra line 1", "extra line 2"},
+	args:    []interface{}{[]interface{}{cmpEqualsWant, "extra line 1"}},
+	verbose: true,
+	expectedCheckFailure: fmt.Sprintf(`
+error:
+  values are not deep equal
+diff (-got +want):
+%s
+got:
+  []interface {}{
+      struct { Strings []interface {}; Ints []int }{
+          Strings: {
+              "who",
+              "dalek",
+          },
+          Ints: {42},
+      },
+      "extra line 1",
+      "extra line 2",
+  }
+want:
+  []interface {}{
+      struct { Strings []interface {}; Ints []int }{
+          Strings: {
+              "who",
+              "dalek",
+          },
+          Ints: {42},
+      },
+      "extra line 1",
+  }
+`, diff([]interface{}{cmpEqualsWant, "extra line 1", "extra line 2"}, []interface{}{cmpEqualsWant, "extra line 1"})),
 }, {
 	about:   "CmpEquals: same values with options",
 	checker: qt.CmpEquals(sameInts),
@@ -467,20 +514,6 @@ want:
 	args: []interface{}{
 		[]int{3, 2, 1},
 	},
-	expectedCheckFailure: fmt.Sprintf(`
-error:
-  values are not deep equal
-diff (-got +want):
-%s
-`, diff([]int{1, 2, 4}, []int{3, 2, 1}, sameInts)),
-}, {
-	about:   "CmpEquals: different values with options: verbose",
-	checker: qt.CmpEquals(sameInts),
-	got:     []int{1, 2, 4},
-	args: []interface{}{
-		[]int{3, 2, 1},
-	},
-	verbose: true,
 	expectedCheckFailure: fmt.Sprintf(`
 error:
   values are not deep equal
@@ -616,18 +649,6 @@ error:
   values are not deep equal
 diff (-got +want):
 %s
-`, diff(cmpEqualsGot, cmpEqualsWant)),
-}, {
-	about:   "DeepEquals: different values: verbose",
-	checker: qt.DeepEquals,
-	got:     cmpEqualsGot,
-	args:    []interface{}{cmpEqualsWant},
-	verbose: true,
-	expectedCheckFailure: fmt.Sprintf(`
-error:
-  values are not deep equal
-diff (-got +want):
-%s
 got:
   struct { Strings []interface {}; Ints []int }{
       Strings: {
@@ -645,6 +666,68 @@ want:
       Ints: {42},
   }
 `, diff(cmpEqualsGot, cmpEqualsWant)),
+}, {
+	about:   "DeepEquals: different values: long output",
+	checker: qt.DeepEquals,
+	got:     []interface{}{cmpEqualsWant, cmpEqualsWant},
+	args:    []interface{}{[]interface{}{cmpEqualsWant, cmpEqualsWant, 42}},
+	expectedCheckFailure: fmt.Sprintf(`
+error:
+  values are not deep equal
+diff (-got +want):
+%s
+got:
+  <suppressed because too long, use -v for the full output>
+want:
+  <same as "got">
+`, diff([]interface{}{cmpEqualsWant, cmpEqualsWant}, []interface{}{cmpEqualsWant, cmpEqualsWant, 42})),
+}, {
+	about:   "DeepEquals: different values: long output and verbose",
+	checker: qt.DeepEquals,
+	got:     []interface{}{cmpEqualsWant, cmpEqualsWant},
+	args:    []interface{}{[]interface{}{cmpEqualsWant, cmpEqualsWant, 42}},
+	verbose: true,
+	expectedCheckFailure: fmt.Sprintf(`
+error:
+  values are not deep equal
+diff (-got +want):
+%s
+got:
+  []interface {}{
+      struct { Strings []interface {}; Ints []int }{
+          Strings: {
+              "who",
+              "dalek",
+          },
+          Ints: {42},
+      },
+      struct { Strings []interface {}; Ints []int }{
+          Strings: {
+              "who",
+              "dalek",
+          },
+          Ints: {42},
+      },
+  }
+want:
+  []interface {}{
+      struct { Strings []interface {}; Ints []int }{
+          Strings: {
+              "who",
+              "dalek",
+          },
+          Ints: {42},
+      },
+      struct { Strings []interface {}; Ints []int }{
+          Strings: {
+              "who",
+              "dalek",
+          },
+          Ints: {42},
+      },
+      int(42),
+  }
+`, diff([]interface{}{cmpEqualsWant, cmpEqualsWant}, []interface{}{cmpEqualsWant, cmpEqualsWant, 42})),
 }, {
 	about:   "ContentEquals: same values",
 	checker: qt.ContentEquals,
@@ -779,6 +862,13 @@ error:
   values are not deep equal
 diff (-got +want):
 %s
+got:
+  []string{"bad", "wolf"}
+want:
+  []interface {}{
+      "bad",
+      "wolf",
+  }
 `, diff([]string{"bad", "wolf"}, []interface{}{"bad", "wolf"})),
 }, {
 	about:   "ContentEquals: not enough arguments",
@@ -2481,14 +2571,18 @@ first mismatched element:
 	checker: qt.All(qt.DeepEquals),
 	got:     [][]string{{"a", "b"}, {"a", "c"}},
 	args:    []interface{}{[]string{"a", "b"}},
-	expectedCheckFailure: `
+	expectedCheckFailure: fmt.Sprintf(`
 error:
   mismatch at index 1
 error:
   values are not deep equal
 diff (-got +want):
-` + diff([]string{"a", "c"}, []string{"a", "b"}) + `
-`,
+%s
+got:
+  []string{"a", "c"}
+want:
+  []string{"a", "b"}
+`, diff([]string{"a", "c"}, []string{"a", "b"})),
 }, {
 	about:   "All bad checker args count",
 	checker: qt.All(qt.IsNil),
@@ -2710,6 +2804,14 @@ error:
   values are not deep equal
 diff (-got +want):
 %s
+got:
+  map[string]interface {}{
+      "NotThere": float64(1),
+  }
+want:
+  map[string]interface {}{
+      "First": float64(2),
+  }
 `, diff(map[string]interface{}{"NotThere": 1.0}, map[string]interface{}{"First": 2.0})),
 }, {
 	about:   "JSONEquals cannot unmarshal obtained value",
@@ -2814,18 +2916,25 @@ want:
 }}
 
 func TestCheckers(t *testing.T) {
+	original := qt.TestingVerbose
+	defer func() {
+		qt.TestingVerbose = original
+	}()
 	for _, test := range checkerTests {
-		checker := qt.WithVerbosity(test.checker, test.verbose)
+		*qt.TestingVerbose = func() bool {
+			return test.verbose
+		}
+
 		t.Run(test.about, func(t *testing.T) {
 			tt := &testingT{}
 			c := qt.New(tt)
-			ok := c.Check(test.got, checker, test.args...)
+			ok := c.Check(test.got, test.checker, test.args...)
 			checkResult(t, ok, tt.errorString(), test.expectedCheckFailure)
 		})
 		t.Run("Not "+test.about, func(t *testing.T) {
 			tt := &testingT{}
 			c := qt.New(tt)
-			ok := c.Check(test.got, qt.Not(checker), test.args...)
+			ok := c.Check(test.got, qt.Not(test.checker), test.args...)
 			checkResult(t, ok, tt.errorString(), test.expectedNegateFailure)
 		})
 	}

--- a/checker_test.go
+++ b/checker_test.go
@@ -436,7 +436,7 @@ want:
 }, {
 	about:   "CmpEquals: different values, long output",
 	checker: qt.CmpEquals(),
-	got:     []interface{}{cmpEqualsWant, "extra line 1", "extra line 2"},
+	got:     []interface{}{cmpEqualsWant, "extra line 1", "extra line 2", "extra line 3"},
 	args:    []interface{}{[]interface{}{cmpEqualsWant, "extra line 1"}},
 	expectedCheckFailure: fmt.Sprintf(`
 error:
@@ -444,7 +444,7 @@ error:
 diff (-got +want):
 %s
 got:
-  <suppressed because too long, use -v for the full output>
+  <suppressed due to length (11 lines), use -v for full output>
 want:
   []interface {}{
       struct { Strings []interface {}; Ints []int }{
@@ -456,7 +456,7 @@ want:
       },
       "extra line 1",
   }
-`, diff([]interface{}{cmpEqualsWant, "extra line 1", "extra line 2"}, []interface{}{cmpEqualsWant, "extra line 1"})),
+`, diff([]interface{}{cmpEqualsWant, "extra line 1", "extra line 2", "extra line 3"}, []interface{}{cmpEqualsWant, "extra line 1"})),
 }, {
 	about:   "CmpEquals: different values: long output and verbose",
 	checker: qt.CmpEquals(),
@@ -677,9 +677,9 @@ error:
 diff (-got +want):
 %s
 got:
-  <suppressed because too long, use -v for the full output>
+  <suppressed due to length (15 lines), use -v for full output>
 want:
-  <same as "got">
+  <suppressed due to length (16 lines), use -v for full output>
 `, diff([]interface{}{cmpEqualsWant, cmpEqualsWant}, []interface{}{cmpEqualsWant, cmpEqualsWant, 42})),
 }, {
 	about:   "DeepEquals: different values: long output and verbose",

--- a/export_test.go
+++ b/export_test.go
@@ -2,30 +2,7 @@
 
 package quicktest
 
-var Prefixf = prefixf
-
-// WithVerbosity returns the given checker with a verbosity level of v.
-// A copy of the original checker is made if mutating is required.
-func WithVerbosity(c Checker, v bool) Checker {
-	switch checker := c.(type) {
-	case *allChecker:
-		c := *checker
-		c.elemChecker = WithVerbosity(c.elemChecker, v)
-		return &c
-	case *anyChecker:
-		c := *checker
-		c.elemChecker = WithVerbosity(c.elemChecker, v)
-		return &c
-	case *cmpEqualsChecker:
-		c := *checker
-		c.verbose = func() bool {
-			return v
-		}
-		return &c
-	case *codecEqualChecker:
-		c := *checker
-		c.deepEquals = WithVerbosity(c.deepEquals, v)
-		return &c
-	}
-	return c
-}
+var (
+	Prefixf        = prefixf
+	TestingVerbose = &testingVerbose
+)

--- a/report.go
+++ b/report.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
+	"testing"
 )
 
 // reportParams holds parameters for reporting a test error.
@@ -37,6 +38,18 @@ type reportParams struct {
 // provided value to be quoted.
 type Unquoted string
 
+// SuppressedIfLong indicates that the value must be suppressed if verbose
+// testing is off and the pretty printed version of the value is long. This is
+// useful when a checker calls note and does not want the provided value to be
+// printed in non-verbose test runs if the value is too long.
+type SuppressedIfLong struct {
+	// Value holds the original annotated value.
+	Value interface{}
+}
+
+// longValueLines holds the number of lines after which a value is long.
+const longValueLines = 10
+
 // report generates a failure report for the given error, optionally including
 // in the output the checker arguments, comment and notes included in the
 // provided report parameters.
@@ -58,6 +71,11 @@ func writeError(w io.Writer, err error, p reportParams) {
 		var v string
 		if u, ok := value.(Unquoted); ok {
 			v = string(u)
+		} else if s, ok := value.(SuppressedIfLong); ok {
+			v = p.format(s.Value)
+			if !testingVerbose() && strings.Count(v, "\n") >= longValueLines {
+				v = "<suppressed because too long, use -v for the full output>"
+			}
 		} else {
 			v = p.format(value)
 		}
@@ -103,6 +121,11 @@ func writeError(w io.Writer, err error, p reportParams) {
 	for i, arg := range append([]interface{}{p.got}, p.args...) {
 		printPair(p.argNames[i], arg)
 	}
+}
+
+// testingVerbose is defined as a variable for testing.
+var testingVerbose = func() bool {
+	return testing.Verbose()
 }
 
 // writeStack writes the traceback information for the current failure into the

--- a/report.go
+++ b/report.go
@@ -73,8 +73,10 @@ func writeError(w io.Writer, err error, p reportParams) {
 			v = string(u)
 		} else if s, ok := value.(SuppressedIfLong); ok {
 			v = p.format(s.Value)
-			if !testingVerbose() && strings.Count(v, "\n") >= longValueLines {
-				v = "<suppressed because too long, use -v for the full output>"
+			if !testingVerbose() {
+				if n := strings.Count(v, "\n"); n > longValueLines {
+					v = fmt.Sprintf("<suppressed due to length (%d lines), use -v for full output>", n)
+				}
 			}
 		} else {
 			v = p.format(value)

--- a/report_test.go
+++ b/report_test.go
@@ -109,8 +109,7 @@ func TestCmpReportOutput(t *testing.T) {
 	}, {
 		AnInt: 1,
 	}, {}}
-	checker := qt.WithVerbosity(qt.DeepEquals, false)
-	c.Assert(gotExamples, checker, wantExamples)
+	c.Assert(gotExamples, qt.DeepEquals, wantExamples)
 	want := `
 error:
   values are not deep equal
@@ -123,9 +122,24 @@ diff (-got +want):
   -         &{AnInt: 2},
   +         &{},
     }
+got:
+  []*quicktest_test.reportExample{
+      &quicktest_test.reportExample{AnInt:42},
+      &quicktest_test.reportExample{AnInt:47},
+      &quicktest_test.reportExample{AnInt:1},
+      &quicktest_test.reportExample{AnInt:2},
+  }
+want:
+  []*quicktest_test.reportExample{
+      &quicktest_test.reportExample{AnInt:42},
+      &quicktest_test.reportExample{AnInt:47},
+      &quicktest_test.reportExample{AnInt:2},
+      &quicktest_test.reportExample{AnInt:1},
+      &quicktest_test.reportExample{},
+  }
 stack:
-  $file:113
-    c.Assert(gotExamples, checker, wantExamples)
+  $file:112
+    c.Assert(gotExamples, qt.DeepEquals, wantExamples)
 `
 	assertReport(t, tt, want)
 }
@@ -141,7 +155,7 @@ got:
 want:
   int(47)
 stack:
-  $file:135
+  $file:149
     qt.Assert(tt, 42, qt.Equals, 47)
 `
 	assertReport(t, tt, want)


### PR DESCRIPTION
Only suppress got/want arguments for CmpEquals (and derived checkers) if the pretty printed representation is small enough and `-v` is not provided.