### PR TITLE
Turn a panicking cmp.Diff into a bad check

### DIFF
--- a/checker.go
+++ b/checker.go
@@ -131,7 +131,7 @@ func (c *cmpEqualsChecker) Check(got interface{}, args []interface{}, note func(
 		// structs with unexported fields and neither AllowUnexported nor
 		// cmpopts.IgnoreUnexported are provided.
 		if r := recover(); r != nil {
-			err = fmt.Errorf("%s", r)
+			err = BadCheckf("%s", r)
 		}
 	}()
 	want := args[0]

--- a/checker_test.go
+++ b/checker_test.go
@@ -537,13 +537,15 @@ want:
 	},
 	expectedCheckFailure: `
 error:
-  cannot handle unexported field at root.answer:
+  bad check: cannot handle unexported field at root.answer:
   	"github.com/frankban/quicktest_test".(struct { answer int })
   consider using a custom Comparer; if you control the implementation of type, you can also consider using an Exporter, AllowUnexported, or cmpopts.IgnoreUnexported
-got:
-  struct { answer int }{answer:42}
-want:
-  <same as "got">
+`,
+	expectedNegateFailure: `
+error:
+  bad check: cannot handle unexported field at root.answer:
+  	"github.com/frankban/quicktest_test".(struct { answer int })
+  consider using a custom Comparer; if you control the implementation of type, you can also consider using an Exporter, AllowUnexported, or cmpopts.IgnoreUnexported
 `,
 }, {
 	about:   "CmpEquals: structs with unexported fields ignored",


### PR DESCRIPTION
Using Not(DeepEquals) on a type with an unexported field currently succeeds without an error. This is because the unexported field is raised as a panic by go-cmp, which is turned into a plain error by the library. Not then interprets the error to mean "not equal" instead of forwarding it to the user.

Fix this by turning any go-cmp panics into a bad check.

Fixes #153