### PR TITLE
Simplify Defer: do not wrap first deferred func

### DIFF
--- a/quicktest.go
+++ b/quicktest.go
@@ -129,11 +129,13 @@ func (c *C) Defer(f func()) {
 	}
 
 	oldDeferred := c.deferred
-	c.deferred = func() {
-		if oldDeferred != nil {
+	if oldDeferred != nil {
+		c.deferred = func() {
 			defer oldDeferred()
+			f()
 		}
-		f()
+	} else {
+		c.deferred = f
 	}
 }
 


### PR DESCRIPTION
Faster call to the deferred function for the most common case (a single Defer call).

Note: this change applies to the pre-Go 1.14 code where `TB.Cleanup` didn't exist.