### PR TITLE
README: fix online godoc link and rebuild

### DIFF
--- a/.godocdown.template
+++ b/.godocdown.template
@@ -1,13 +1,13 @@
-[![GoDoc](https://godoc.org/github.com/frankban/quicktest?status.svg)](https://godoc.org/github.com/frankban/quicktest)
+[![Go Reference](https://pkg.go.dev/badge/github.com/frankban/quicktest.svg)](https://pkg.go.dev/github.com/frankban/quicktest#section-documentation)
 [![Build Status](https://github.com/frankban/quicktest/actions/workflows/ci.yaml/badge.svg)](https://github.com/frankban/quicktest/actions/workflows/ci.yaml)
 
-[//]: # (Generated with: godocdown -template=.godocdown.template -o README.md)
+[//]: # (Generated with: godocdown -template=.godocdown.template -o README.md && sed -i= 's/^# /### /' README.md )
 
 # quicktest
 
-`go get github.com/frankban/quicktest`
+`go get github.com/frankban/quicktest@latest`
 
 {{ .EmitSynopsis }}
 
 For a complete API reference, see the
-[package documentation](https://pkg.go.dev/github.com/frankban/quicktest).
+[package documentation](https://pkg.go.dev/github.com/frankban/quicktest#section-documentation).

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-[![GoDoc](https://godoc.org/github.com/frankban/quicktest?status.svg)](https://godoc.org/github.com/frankban/quicktest)
+[![Go Reference](https://pkg.go.dev/badge/github.com/frankban/quicktest.svg)](https://pkg.go.dev/github.com/frankban/quicktest#section-documentation)
 [![Build Status](https://github.com/frankban/quicktest/actions/workflows/ci.yaml/badge.svg)](https://github.com/frankban/quicktest/actions/workflows/ci.yaml)
 
 [//]: # (Generated with: godocdown -template=.godocdown.template -o README.md)
 
-# quicktest
+### quicktest
 
-`go get github.com/frankban/quicktest`
+`go get github.com/frankban/quicktest@latest`
 
 Package quicktest provides a collection of Go helpers for writing tests.
 
@@ -33,7 +33,6 @@ instance:
         })
     }
 
-
 ### Assertions
 
 An assertion looks like this, where qt.Equals could be replaced by any available
@@ -58,7 +57,6 @@ ErrorMatches, IsNil and others. More can be added by implementing the Checker
 interface. Below, we list the checkers implemented by the package in
 alphabetical order.
 
-
 ### All
 
 All returns a Checker that uses the given checker to check elements of slice or
@@ -72,7 +70,6 @@ For example:
 
 See also Any and Contains.
 
-
 ### Any
 
 Any returns a Checker that uses the given checker to check elements of a slice
@@ -85,7 +82,6 @@ For example:
 
 See also All and Contains.
 
-
 ### CmpEquals
 
 CmpEquals checks equality of two arbitrary values according to the provided
@@ -96,7 +92,6 @@ Example calls:
 
     c.Assert(list, qt.CmpEquals(cmpopts.SortSlices), []int{42, 47})
     c.Assert(got, qt.CmpEquals(), []int{42, 47}) // Same as qt.DeepEquals.
-
 
 ### CodecEquals
 
@@ -120,7 +115,6 @@ using CmpEquals(opts) to perform the check.
 
 See JSONEquals for an example of this in use.
 
-
 ### Contains
 
 Contains checks that a map, slice, array or string contains a value. It's the
@@ -133,7 +127,6 @@ For example:
     c.Assert("hello world", qt.Contains, "world")
     c.Assert([]int{3,5,7,99}, qt.Contains, 7)
 
-
 ### ContentEquals
 
 ContentEquals is is like DeepEquals but any slices in the compared values will
@@ -142,7 +135,6 @@ be sorted before being compared.
 For example:
 
     c.Assert([]string{"c", "a", "b"}, qt.ContentEquals, []string{"a", "b", "c"})
-
 
 ### DeepEquals
 
@@ -154,7 +146,6 @@ required, use CmpEquals (see below).
 Example call:
 
     c.Assert(got, qt.DeepEquals, []int{42, 47})
-
 
 ### Equals
 
@@ -169,7 +160,6 @@ Note that the following will fail:
     c.Assert((*sometype)(nil), qt.Equals, nil)
 
 Use the IsNil checker below for this kind of nil check.
-
 
 ### ErrorAs
 
@@ -187,7 +177,6 @@ For instance:
         c.Assert(pathError.Path, Equals, "some_path")
     }
 
-
 ### ErrorIs
 
 ErrorIs checks that the error is or wraps a specific error value. This is
@@ -197,7 +186,6 @@ For instance:
 
     c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 
-
 ### ErrorMatches
 
 ErrorMatches checks that the provided value is an error whose message matches
@@ -206,8 +194,6 @@ the provided regular expression.
 For instance:
 
     c.Assert(err, qt.ErrorMatches, `bad wolf .*`)
-    c.Assert(err, qt.ErrorMatches, regexp.MustCompile("bad wolf .*"))
-
 
 ### HasLen
 
@@ -217,7 +203,6 @@ For instance:
 
     c.Assert([]int{42, 47}, qt.HasLen, 2)
     c.Assert(myMap, qt.HasLen, 42)
-
 
 ### Implements
 
@@ -229,7 +214,6 @@ For instance:
     var rc io.ReadCloser
     c.Assert(myReader, qt.Implements, &rc)
 
-
 ### IsFalse
 
 IsFalse checks that the provided value is false. The value must have a boolean
@@ -239,7 +223,6 @@ For instance:
 
     c.Assert(false, qt.IsFalse)
     c.Assert(IsValid(), qt.IsFalse)
-
 
 ### IsNil
 
@@ -258,7 +241,6 @@ So it's just fine to check an error like this:
 
     c.Assert(err, qt.IsNil)
 
-
 ### IsNotNil
 
 IsNotNil is a Checker checking that the provided value is not nil. IsNotNil is
@@ -267,7 +249,6 @@ the equivalent of qt.Not(qt.IsNil)
 For instance:
 
     c.Assert(got, qt.IsNotNil)
-
 
 ### IsTrue
 
@@ -278,7 +259,6 @@ For instance:
 
     c.Assert(true, qt.IsTrue)
     c.Assert(myBoolean(false), qt.IsTrue)
-
 
 ### JSONEquals
 
@@ -292,7 +272,6 @@ For instance:
 
     c.Assert(`{"First": 47.11}`, qt.JSONEquals, &MyStruct{First: 47.11})
 
-
 ### Matches
 
 Matches checks that a string or result of calling the String method (if the
@@ -302,8 +281,6 @@ For instance:
 
     c.Assert("these are the voyages", qt.Matches, `these are .*`)
     c.Assert(net.ParseIP("1.2.3.4"), qt.Matches, `1.*`)
-    c.Assert("line 1\nline 2", qt.Matches, regexp.MustCompile(`line \d\nline \d`))
-
 
 ### Not
 
@@ -314,7 +291,6 @@ For instance:
     c.Assert(got, qt.Not(qt.IsNil))
     c.Assert(answer, qt.Not(qt.Equals), 42)
 
-
 ### PanicMatches
 
 PanicMatches checks that the provided function panics with a message matching
@@ -323,8 +299,6 @@ the provided regular expression.
 For instance:
 
     c.Assert(func() {panic("bad wolf ...")}, qt.PanicMatches, `bad wolf .*`)
-    c.Assert(func() {panic("bad wolf ...")}, qt.PanicMatches, regexp.MustCompile(`bad wolf .*`))
-
 
 ### Satisfies
 
@@ -339,7 +313,6 @@ For instance:
 
     // Check that a floating point number is a not-a-number.
     c.Assert(f, qt.Satisfies, math.IsNaN)
-
 
 ### Deferred Execution
 
@@ -371,4 +344,4 @@ The c.Patch, c.Setenv, c.Unsetenv and c.Mkdir helpers use t.Cleanup for cleaning
 up resources when available, and fall back to Defer otherwise.
 
 For a complete API reference, see the
-[package documentation](https://pkg.go.dev/github.com/frankban/quicktest).
+[package documentation](https://pkg.go.dev/github.com/frankban/quicktest#section-documentation).


### PR DESCRIPTION
README.md:
* fix GoDoc badge to use pkg.go.dev
* fix "go get" instruction to use module style
* fix build instruction to patch godocdown output to handle how section titles are formatted by gofmt in Go 1.18+: add `sed -i= 's/^# /### /' README.md` step
* rebuild README.md

Build instructions:

```console
$ go install github.com/robertkrimen/godocdown/godocdown@latest
$ godocdown -template=.godocdown.template -o README.md
$ sed -i= 's/^# /### /' README.md
```