### PR TITLE
Failure output: avoid using the 'same as' logic for suppressed values

### DIFF
--- a/checker_test.go
+++ b/checker_test.go
@@ -494,6 +494,21 @@ want:
   }
 `, diff([]interface{}{cmpEqualsWant, "extra line 1", "extra line 2"}, []interface{}{cmpEqualsWant, "extra line 1"})),
 }, {
+	about:   "CmpEquals: different values, long output, same number of lines",
+	checker: qt.CmpEquals(),
+	got:     []interface{}{cmpEqualsWant, "extra line 1", "extra line 2", "extra line 3"},
+	args:    []interface{}{[]interface{}{cmpEqualsWant, "extra line 1", "extra line 2", "extra line three"}},
+	expectedCheckFailure: fmt.Sprintf(`
+error:
+  values are not deep equal
+diff (-got +want):
+%s
+got:
+  <suppressed due to length (11 lines), use -v for full output>
+want:
+  <suppressed due to length (11 lines), use -v for full output>
+`, diff([]interface{}{cmpEqualsWant, "extra line 1", "extra line 2", "extra line 3"}, []interface{}{cmpEqualsWant, "extra line 1", "extra line 2", "extra line three"})),
+}, {
 	about:   "CmpEquals: same values with options",
 	checker: qt.CmpEquals(sameInts),
 	got:     []int{1, 2, 3},


### PR DESCRIPTION
For a DeepEquals test, you could have an output like:
```
error:
  values are not deep equal
diff (-got +want):
    []any{
            struct{ Strings []any; Ints []int }{Strings: {string("who"), string("dalek")}, Ints: {42}},
            string("extra line 1"),
  -         string("extra line 2"),
  -         string("extra line 3"),
    }
got:
  <suppressed due to length (11 lines), use -v for full output>
want:
  <same as got>
```
I've found the `<same as got>` in this case a bit confusing, as it seems to refer more to the actual value, rather than the suppressed message.

With this branch, the output is now more explicit:
```
error:
  values are not deep equal
diff (-got +want):
    []any{
            struct{ Strings []any; Ints []int }{Strings: {string("who"), string("dalek")}, Ints: {42}},
            string("extra line 1"),
  -         string("extra line 2"),
  -         string("extra line 3"),
    }
got:
  <suppressed due to length (11 lines), use -v for full output>
want:
  <suppressed due to length (11 lines), use -v for full output>
```