### PR TITLE
tests: fix missing call to `Done()` in `TestCDeferVsCleanupOrder`

### DIFF
--- a/cleanup_test.go
+++ b/cleanup_test.go
@@ -61,6 +61,7 @@ func TestCDeferVsCleanupOrder(t *testing.T) {
 	c := qt.New(t)
 	var defers []int
 	c.Run("subtest", func(c *qt.C) {
+		defer c.Done()
 		c.Defer(func() {
 			defers = append(defers, 0)
 		})


### PR DESCRIPTION
In TestCDeferVsCleanupOrder fix a missing call to `c.Done()` after calls to `c.Defer()`.