### PR TITLE
Add test for C.Run for more coverage

### DIFF
--- a/quicktest_test.go
+++ b/quicktest_test.go
@@ -527,6 +527,27 @@ want:
 `)
 }
 
+func TestCRunFormatWithC(t *testing.T) {
+	tt, innerTT := &testingT{}, &testingT{}
+	// Wrap the C with another C so the C.Run has to call a Run(string, func(*C) bool) instead of Run(string, func(*testing.T) bool)
+	c := qt.New(qt.New(tt))
+	c.SetFormat(func(v interface{}) string {
+		return fmt.Sprintf("myfmt(%v)", v)
+	})
+	c.Run("my test", func(innerC *qt.C) {
+		innerC.TB = innerTT
+		innerC.Check(42, qt.Equals, nil)
+	})
+	assertPrefix(t, innerTT.errorString(), `
+error:
+  values are not equal
+got:
+  myfmt(42)
+want:
+  myfmt(<nil>)
+`)
+}
+
 func TestHelper(t *testing.T) {
 	tt := &testingT{}
 	qt.Assert(tt, true, qt.IsFalse)


### PR DESCRIPTION
Add `TestCRunFormatWithC` (derived from `TestCRunFormat `) to alse check that Format is passed from the parent to the child when c.TB has a Run method with signature `func(string, func(*C) bool)`.

This added coverage will be helpful to check alternative implementations of C.Run such as #165 and #166 (see https://github.com/frankban/quicktest/pull/166#discussion_r1281720999).

Cc: @rogpeppe 