### PR TITLE
give type mismatch hint when checker fails for same value but wrong type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+.idea

--- a/checker.go
+++ b/checker.go
@@ -100,6 +100,17 @@ func (c *equalsChecker) Check(got interface{}, args []interface{}, note func(key
 		}
 	}
 
+	// Show type hint when string values are equal but have different types (e.g., a string type alias).
+	gotVal := reflect.ValueOf(got)
+	wantVal := reflect.ValueOf(want)
+	if gotVal.IsValid() && wantVal.IsValid() &&
+		gotVal.Kind() == reflect.String && wantVal.Kind() == reflect.String &&
+		reflect.TypeOf(got) != reflect.TypeOf(want) &&
+		gotVal.String() == wantVal.String() {
+		note("got type", Unquoted(reflect.TypeOf(got).String()))
+		note("want type", Unquoted(reflect.TypeOf(want).String()))
+	}
+
 	return errors.New("values are not equal")
 }
 

--- a/checker.go
+++ b/checker.go
@@ -100,17 +100,6 @@ func (c *equalsChecker) Check(got interface{}, args []interface{}, note func(key
 		}
 	}
 
-	// Show type hint when string values are equal but have different types (e.g., a string type alias).
-	gotVal := reflect.ValueOf(got)
-	wantVal := reflect.ValueOf(want)
-	if gotVal.IsValid() && wantVal.IsValid() &&
-		gotVal.Kind() == reflect.String && wantVal.Kind() == reflect.String &&
-		reflect.TypeOf(got) != reflect.TypeOf(want) &&
-		gotVal.String() == wantVal.String() {
-		note("got type", Unquoted(reflect.TypeOf(got).String()))
-		note("want type", Unquoted(reflect.TypeOf(want).String()))
-	}
-
 	return errors.New("values are not equal")
 }
 

--- a/checker_test.go
+++ b/checker_test.go
@@ -63,6 +63,8 @@ type OuterJSON struct {
 
 type boolean bool
 
+type stringAlias string
+
 var checkerTests = []struct {
 	about                 string
 	checker               qt.Checker
@@ -178,6 +180,23 @@ got:
   int(42)
 want:
   "42"
+`,
+}, {
+	about:   "Equals: string alias with same value shows type hint",
+	checker: qt.Equals,
+	got:     stringAlias("CONSTANT"),
+	args:    []interface{}{"CONSTANT"},
+	expectedCheckFailure: `
+error:
+  values are not equal
+got type:
+  quicktest_test.stringAlias
+want type:
+  string
+got:
+  "CONSTANT"
+want:
+  <same as "got">
 `,
 }, {
 	about:   "Equals: nil and nil",

--- a/checker_test.go
+++ b/checker_test.go
@@ -62,8 +62,7 @@ type OuterJSON struct {
 }
 
 type boolean bool
-
-type stringAlias string
+type myString string
 
 var checkerTests = []struct {
 	about                 string
@@ -182,21 +181,17 @@ want:
   "42"
 `,
 }, {
-	about:   "Equals: string alias with same value shows type hint",
+	about:   "Equals: string and named string type with same value",
 	checker: qt.Equals,
-	got:     stringAlias("CONSTANT"),
-	args:    []interface{}{"CONSTANT"},
+	got:     "hello",
+	args:    []interface{}{myString("hello")},
 	expectedCheckFailure: `
 error:
   values are not equal
-got type:
-  quicktest_test.stringAlias
-want type:
-  string
 got:
-  "CONSTANT"
+  "hello"
 want:
-  <same as "got">
+  quicktest_test.myString("hello")
 `,
 }, {
 	about:   "Equals: nil and nil",

--- a/format.go
+++ b/format.go
@@ -46,6 +46,14 @@ func Format(v interface{}) string {
 		// (json.RawMessage for example).
 		return fmt.Sprintf("%T(%s)", v, quoteString(string(bytes)))
 	}
+	// Handle named string types (e.g. type myString string) explicitly so that
+	// the type name is included in the output. Without this they fall through to
+	// pretty.Formatter which renders them as a plain quoted string, identical to
+	// a plain string value, causing the deduplication in the reporter to
+	// incorrectly print "<same as got>" when the types differ.
+	if rv := reflect.ValueOf(v); rv.IsValid() && rv.Kind() == reflect.String {
+		return fmt.Sprintf("%T(%s)", v, quoteString(rv.String()))
+	}
 	// The pretty.Sprint equivalent does not quote string values.
 	return fmt.Sprintf("%# v", pretty.Formatter(v))
 }


### PR DESCRIPTION
Imagine below test case
```
type Alias string
const stringAlias Alias = "CONSTANT"
constant := ""CONSTANT

Assert(stringAlias, qt.Equals, constant) // fails
```
this fails rightfully but there is no hint from the checker that it failed on the type and not value.

This PR add another check for type so we can receive that hint